### PR TITLE
Fix canceling asset loads on singlethreaded.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,6 +389,9 @@ free_camera = ["bevy_internal/free_camera"]
 # Enables the pan camera from bevy_camera_controller
 pan_camera = ["bevy_internal/pan_camera"]
 
+# Enables the pan orbit camera from bevy_camera_controller
+pan_orbit_camera = ["bevy_internal/pan_orbit_camera"]
+
 # Enable the Bevy Remote Protocol
 bevy_remote = ["bevy_internal/bevy_remote"]
 
@@ -5587,6 +5590,42 @@ required-features = ["pan_camera"]
 [package.metadata.example.pan_camera_controller]
 name = "Pan Camera"
 description = "Example Pan-Camera Styled Camera Controller for 2D scenes"
+category = "Camera"
+wasm = true
+
+[[example]]
+name = "pan_orbit_camera_cad"
+path = "examples/camera/pan_orbit_camera_cad.rs"
+doc-scrape-examples = true
+required-features = ["pan_orbit_camera", "https", "3d_api", "jpeg"]
+
+[package.metadata.example.pan_orbit_camera_cad]
+name = "Pan Orbit Camera"
+description = "CAD-like controls and setup for PanOrbitCamera"
+category = "Camera"
+wasm = true
+
+[[example]]
+name = "pan_orbit_camera_minimal"
+path = "examples/camera/pan_orbit_camera_minimal.rs"
+doc-scrape-examples = true
+required-features = ["pan_orbit_camera", "https", "3d_api", "jpeg"]
+
+[package.metadata.example.pan_orbit_camera_minimal]
+name = "Minimal Pan Orbit Camera"
+description = "Minimum setup for working PanOrbitCamera"
+category = "Camera"
+wasm = true
+
+[[example]]
+name = "pan_orbit_camera_ortho"
+path = "examples/camera/pan_orbit_camera_ortho.rs"
+doc-scrape-examples = true
+required-features = ["pan_orbit_camera", "https", "3d_api", "jpeg"]
+
+[package.metadata.example.pan_orbit_camera_ortho]
+name = "Orthographic Pan Orbit Camera"
+description = "Using Pan Orbit Camera in orthographic-only projection"
 category = "Camera"
 wasm = true
 

--- a/_release-content/migration-guides/bevy_color_hdr_clamps.md
+++ b/_release-content/migration-guides/bevy_color_hdr_clamps.md
@@ -1,0 +1,14 @@
+---
+title: "`with_luminance` no longer clamps in `bevy_color`"
+pull_requests: [25394]
+---
+
+`LinearRgba::with_luminance` now scales the components to the target luminance and does
+not clamp the result, so HDR and wide-gamut values survive. A saturated color or a target
+above 1.0 can produce components outside `[0.0, 1.0]`. Operations that convert through it,
+such as `Srgba::with_luminance` and `Color::with_luminance`, change the same way.
+The `Laba` to `Lcha` conversion now retains the color's full gamut.
+
+If you were using these methods to bring colors back into SDR range, you'll now need
+to clamp explicitly with `c.red.clamp(0., 1.)`. Alternatively, convert through
+`ColorToPacked`, which still quantizes colors to [0, 1].

--- a/_release-content/migration-guides/default_font_size_is_rem.md
+++ b/_release-content/migration-guides/default_font_size_is_rem.md
@@ -1,0 +1,17 @@
+---
+title: "`TextFont::default()` font size is now `FontSize::Rem(1.)`"
+pull_requests: [25231]
+---
+
+`TextFont::default()` now uses `FontSize::Rem(1.)` instead of `FontSize::Px(20.)`, so that the
+`RemSize` resource actually sets the default font size. With the default `RemSize` of 20 logical
+pixels this renders identically, but text left at the default size now scales when `RemSize`
+changes. To keep a fixed size, set it explicitly:
+
+```rust
+// 0.20
+TextFont {
+    font_size: FontSize::Px(20.),
+    ..default()
+}
+```

--- a/_release-content/migration-guides/val_em_and_rem.md
+++ b/_release-content/migration-guides/val_em_and_rem.md
@@ -1,0 +1,59 @@
+---
+title: "Val::Em and Val::Rem"
+pull_requests: [25231]
+---
+
+`Val` has two new variants, `Val::Em` and `Val::Rem`, which size a length relative to a font size.
+`Val::Em` resolves against the font size of the node it is set on, `Val::Rem` against the
+`RemSize` resource. The `em` and `rem` helper functions construct them, alongside the existing `px`,
+`percent`, `vw` and `vh`.
+
+Resolving a `Val` now needs both of those font sizes, so the following methods take two additional
+arguments, `em_size: EmSize` and `rem_size: RemSize`:
+
+- `Val::resolve`
+- `Val2::resolve`
+- `UiPosition::resolve`
+- `CornerRadius::resolve`
+- `RadialGradientShape::resolve`
+- `UiTransform::compute_affine`
+- `BorderRadius::resolve`
+
+```rust
+// 0.19
+let physical = val.resolve(scale_factor, physical_base_value, physical_target_size)?;
+
+// 0.20
+let physical = val.resolve(
+    scale_factor,
+    physical_base_value,
+    physical_target_size,
+    em_size,
+    rem_size,
+)?;
+```
+
+`ComputedNode` has new `em_size` and `rem_size` fields holding the values that were used to lay the
+node out, so when resolving a `Val` against an existing node you can take them from there (`box_shadow`
+for example).
+
+`Node` now requires `EmSize` (from `bevy_text`, re-exported in `bevy_ui::prelude`), the per-node
+font size that `Val::Em` resolves against. If the node has a `TextFont`, `EmSize` is recomputed when `TextFont`,
+`RemSize`, or render-target info changes; values you set persist until then. If the node does not
+have a `TextFont` component then the value is yours to set and is left alone; it defaults to
+`DEFAULT_REM_SIZE_PX`, which matches the default `RemSize` but does not track changes to it. Propagating
+`EmSize` is the responsibility of an app, not `bevy_ui`.
+
+Use `GridTrack::em`, `GridTrack::rem`, `RepeatedGridTrack::em` and `RepeatedGridTrack::rem` to construct
+grid tracks sized in these units using new `MinTrackSizingFunction::Em`, `MinTrackSizingFunction::Rem`,
+`MaxTrackSizingFunction::Em` and `MaxTrackSizingFunction::Rem` variants.
+
+`FontSize::eval` now takes a `RemSize` rather than an `f32`:
+
+```rust
+// 0.19
+let size = font_size.eval(logical_viewport_size, rem_size_px);
+
+// 0.20
+let size = font_size.eval(logical_viewport_size, RemSize(rem_size_px));
+```

--- a/_release-content/release-notes/bevy_color_primaries.md
+++ b/_release-content/release-notes/bevy_color_primaries.md
@@ -1,0 +1,11 @@
+---
+title: "RGB primaries and conversion matrices in `bevy_color`"
+authors: ["@stuartparmenter"]
+pull_requests: [25393]
+---
+
+`bevy_color` now has a `primaries` module. It holds constants derived from ITU standards:
+
+- `Chromaticity`, the CIE diagram coordinates.
+- `RgbPrimaries`, with constants for `BT709`, `BT2020`, `DISPLAY_P3`, and `ACES_CG`.
+- `RgbPrimaries::matrix_to`, which derives a conversion matrix between any two primary sets.

--- a/_release-content/release-notes/pan_orbit_camera.md
+++ b/_release-content/release-notes/pan_orbit_camera.md
@@ -1,0 +1,33 @@
+---
+title: Pan Orbit Camera
+authors: ["@aevyrie, @taishi-sama"]
+pull_requests: [25434]
+---
+
+Upstream of awesome crate [`bevy_editor_cam`](https://github.com/aevyrie/bevy_editor_cam) made by [@aevyrie](https://github.com/aevyrie) as part of `bevy_camera_controller` crate!
+
+## Usage
+
+Add `MeshPickingPlugin` and `DefaultPanOrbitCameraPlugins` plugin.
+
+```rust
+app.add_plugins((
+    MeshPickingPlugin,
+    DefaultPanOrbitCameraPlugins,
+))
+```
+
+Then add `PanOrbitCamera` component on any 3D camera.
+
+```rust
+commands.spawn((
+    Camera3d::default(),
+    PanOrbitCamera::default(),
+))
+```
+
+Full functionality is shown in the `camera/pan_orbit_camera_cad` example
+
+```sh
+cargo run --example pan_orbit_camera_cad --features='pan_orbit_camera https 3d_api jpeg'
+```

--- a/_release-content/release-notes/per_column_change_ticks.md
+++ b/_release-content/release-notes/per_column_change_ticks.md
@@ -1,7 +1,7 @@
 ---
 title: Per-column change ticks
-authors: ["@pcwalton"]
-pull_requests: [25157]
+authors: ["@pcwalton", "@SkiFire13"]
+pull_requests: [25157, 25429]
 ---
 
-TODO
+A new summary change tick is now stored per-column, representing the last time any component in that column was changed. This allows skipping the whole column in case no component was changed, as opposed to going through each component checking them individually.

--- a/_release-content/release-notes/val_em_and_rem.md
+++ b/_release-content/release-notes/val_em_and_rem.md
@@ -1,0 +1,24 @@
+---
+title: "Val::Em and Val::Rem"
+authors: ["@gagnus"]
+pull_requests: [25231]
+---
+
+Bevy UI now supports `em` and `rem` as sizing units. `em` is the current font size (represented by an `EmSize` component), `rem` is a
+global "root" font size (represented by the existing `RemSize` resource).
+
+`EmSize` is derived from `TextFont` when one is on the same entity; propagating it down the hierarchy is left to your app.
+
+This is especially useful if you might want to vary your text size after authoring your UIs, for example as an accessibility feature or
+just to improve your UI on different devices.
+
+```rust
+bsn! {
+    Node { width: em(10) }
+    Text("Hello")
+    TextFont { font_size: FontSize::Rem(1.5) }
+}
+```
+
+The default font-size is now `rem(1)` rather than `px(20)`. This is a no-op if you're not changing `RemSize` but it means your
+text will scale by default when you do.

--- a/crates/bevy_asset/src/direct_access_ext.rs
+++ b/crates/bevy_asset/src/direct_access_ext.rs
@@ -3,7 +3,7 @@
 
 use bevy_ecs::world::World;
 
-use crate::{meta::Settings, Asset, AssetPath, AssetServer, Assets, Handle, LoadBuilder};
+use crate::{Asset, AssetPath, AssetServer, Assets, Handle, LoadBuilder};
 
 /// An extension trait for methods for working with assets directly from a [`World`].
 pub trait DirectAssetAccessExt {
@@ -15,14 +15,6 @@ pub trait DirectAssetAccessExt {
 
     /// Creates a new [`LoadBuilder`] similar to [`AssetServer::load_builder`].
     fn load_builder(&self) -> LoadBuilder<'_>;
-
-    /// Load an asset with settings, similarly to [`AssetServer::load_with_settings`].
-    #[deprecated(note = "Use `world.load_builder().with_settings(settings).load(path)`")]
-    fn load_asset_with_settings<'a, A: Asset, S: Settings>(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-        settings: impl Fn(&mut S) + Send + Sync + 'static,
-    ) -> Handle<A>;
 }
 
 impl DirectAssetAccessExt for World {
@@ -48,20 +40,5 @@ impl DirectAssetAccessExt for World {
     /// If `self` doesn't have an [`AssetServer`] resource initialized yet.
     fn load_builder(&self) -> LoadBuilder<'_> {
         self.resource::<AssetServer>().load_builder()
-    }
-
-    /// Load an asset with settings, similarly to [`AssetServer::load_with_settings`].
-    ///
-    /// # Panics
-    /// If `self` doesn't have an [`AssetServer`] resource initialized yet.
-    fn load_asset_with_settings<'a, A: Asset, S: Settings>(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-        settings: impl Fn(&mut S) + Send + Sync + 'static,
-    ) -> Handle<A> {
-        self.resource::<AssetServer>()
-            .load_builder()
-            .with_settings(settings)
-            .load(path.into())
     }
 }

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -63,12 +63,12 @@ impl FilesystemEventHandler for EmbeddedEventHandler {
     }
 
     fn get_path(&self, absolute_path: &Path) -> Option<(PathBuf, bool)> {
-        let (local_path, is_meta) = get_asset_path(&self.root, absolute_path);
+        let (_local_path, is_meta) = get_asset_path(&self.root, absolute_path);
         let final_path = self
             .root_paths
             .read()
             .unwrap_or_else(PoisonError::into_inner)
-            .get(local_path.as_path())?
+            .get(absolute_path)?
             .clone();
         if is_meta {
             warn!("Meta file asset hot-reloading is not supported yet: {final_path:?}");

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -368,10 +368,12 @@ macro_rules! embedded_asset {
 #[doc(hidden)]
 #[cfg(feature = "embedded_watcher")]
 pub fn watched_path(source_file_path: &'static str, asset_path: &'static str) -> PathBuf {
-    PathBuf::from(source_file_path)
-        .parent()
-        .unwrap()
-        .join(asset_path)
+    crate::path::normalize_path(
+        &std::path::absolute(source_file_path).expect("file!() did not return a path"),
+    )
+    .parent()
+    .unwrap()
+    .join(asset_path)
 }
 
 /// Returns an empty PathBuf.

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -739,7 +739,8 @@ mod tests {
         loader::{AssetLoader, LoadContext},
         Asset, AssetApp, AssetEvent, AssetId, AssetLoadError, AssetLoadFailedEvent, AssetPath,
         AssetPlugin, AssetServer, Assets, InvalidGenerationError, LoadState, LoadedAsset,
-        UnapprovedPathMode, UntypedHandle, VisitAssetDependencies, WriteDefaultMetaError,
+        LoadedUntypedAsset, UnapprovedPathMode, UntypedHandle, VisitAssetDependencies,
+        WriteDefaultMetaError,
     };
     use alloc::{
         boxed::Box,
@@ -783,6 +784,42 @@ mod tests {
     #[derive(Asset, TypePath, Debug)]
     pub struct SubText {
         pub text: String,
+    }
+
+    /// An asset whose loader performs a nested *untyped* load, to exercise
+    /// [`NestedLoadBuilder::load_untyped`](crate::NestedLoadBuilder::load_untyped).
+    #[derive(Asset, TypePath, Debug)]
+    pub struct UntypedDependent {
+        #[dependency]
+        pub dependency: Handle<LoadedUntypedAsset>,
+    }
+
+    #[derive(Default, TypePath)]
+    pub struct UntypedDependentLoader;
+
+    impl AssetLoader for UntypedDependentLoader {
+        type Asset = UntypedDependent;
+
+        type Settings = ();
+
+        type Error = std::io::Error;
+
+        async fn load(
+            &self,
+            reader: &mut dyn Reader,
+            _settings: &Self::Settings,
+            load_context: &mut LoadContext<'_>,
+        ) -> Result<Self::Asset, Self::Error> {
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).await?;
+            Ok(UntypedDependent {
+                dependency: load_context.load_builder().load_untyped("../a.cool.ron"),
+            })
+        }
+
+        fn extensions(&self) -> &[&str] {
+            &["untyped_dependent"]
+        }
     }
 
     #[derive(Serialize, Deserialize, Default)]
@@ -2131,6 +2168,22 @@ mod tests {
 
         dir.insert_asset_text(Path::new(a_path), a_ron);
 
+        // An approved asset that declares the unapproved asset above as a dependency, so that the
+        // unapproved path is reached through a nested load from inside an `AssetLoader`.
+        let dependent_path = "dependent.cool.ron";
+        let dependent_ron = r#"
+(
+    text: "dependent",
+    dependencies: ["../a.cool.ron"],
+    embedded_dependencies: [],
+    sub_texts: [],
+)"#;
+
+        dir.insert_asset_text(Path::new(dependent_path), dependent_ron);
+
+        // Reached through a nested *untyped* load; the contents are unused.
+        dir.insert_asset_text(Path::new("dependent.untyped_dependent"), "");
+
         let mut app = App::new();
         let memory_reader = MemoryAssetReader { root: dir };
         app.register_asset_source(
@@ -2190,6 +2243,68 @@ mod tests {
 
         // Make sure this asset actually loads.
         run_app_until(&mut app, |_| asset_server.is_loaded(&handle).then_some(()));
+    }
+
+    /// Regression test for [#21584](https://github.com/bevyengine/bevy/issues/21584).
+    ///
+    /// Rejecting an unapproved path yields a default (`Uuid`) handle, but nested loads assumed
+    /// they always received a `Strong` handle and unwrapped the conversion, panicking inside the
+    /// asset loader. The nested load should instead be skipped, matching the behavior of a
+    /// top-level [`AssetServer::load`] of an unapproved path.
+    #[test]
+    fn unapproved_path_deny_does_not_panic_in_nested_load() {
+        let mut app = unapproved_path_setup(UnapprovedPathMode::Deny);
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let handle = asset_server.load::<CoolText>("dependent.cool.ron");
+
+        run_app_until(&mut app, |_| {
+            matches!(
+                asset_server.load_state(&handle),
+                LoadState::Loaded | LoadState::Failed(_)
+            )
+            .then_some(())
+        });
+
+        assert!(
+            matches!(asset_server.load_state(&handle), LoadState::Loaded),
+            "an unapproved dependency should be rejected without failing the whole load, but got {:?}",
+            asset_server.load_state(&handle)
+        );
+
+        let cool_text = get::<CoolText>(app.world(), handle.id()).unwrap();
+        assert_eq!(cool_text.text, "dependent");
+        // The rejected dependency resolves to a default handle rather than panicking.
+        assert_eq!(cool_text.dependencies, vec![Handle::default()]);
+    }
+
+    /// Regression test for [#21584](https://github.com/bevyengine/bevy/issues/21584), covering the
+    /// untyped nested load path, which rejects unapproved paths the same way.
+    #[test]
+    fn unapproved_path_deny_does_not_panic_in_nested_untyped_load() {
+        let mut app = unapproved_path_setup(UnapprovedPathMode::Deny);
+        app.init_asset::<UntypedDependent>()
+            .register_asset_loader(UntypedDependentLoader);
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let handle = asset_server.load::<UntypedDependent>("dependent.untyped_dependent");
+
+        run_app_until(&mut app, |_| {
+            matches!(
+                asset_server.load_state(&handle),
+                LoadState::Loaded | LoadState::Failed(_)
+            )
+            .then_some(())
+        });
+
+        assert!(
+            matches!(asset_server.load_state(&handle), LoadState::Loaded),
+            "an unapproved untyped dependency should be rejected without failing the whole load, but got {:?}",
+            asset_server.load_state(&handle)
+        );
+
+        let dependent = get::<UntypedDependent>(app.world(), handle.id()).unwrap();
+        assert_eq!(dependent.dependency, Handle::default());
     }
 
     #[test]

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -764,6 +764,7 @@ mod tests {
     use bevy_reflect::{Reflect, TypePath};
     use bevy_tasks::block_on;
     use core::{any::TypeId, time::Duration};
+    use crossbeam_channel::TryRecvError;
     use futures_lite::AsyncReadExt;
     use ron::ser::PrettyConfig;
     use serde::{Deserialize, Serialize};
@@ -2242,6 +2243,9 @@ mod tests {
     struct GatedLoader {
         in_loader_sender: Sender<()>,
         gate_receiver: Receiver<()>,
+        /// An extra sender for indicating whether the task continued after the gate was opened or
+        /// not.
+        finished_sender: Option<crossbeam_channel::Sender<u32>>,
     }
 
     impl AssetLoader for GatedLoader {
@@ -2255,8 +2259,24 @@ mod tests {
             _settings: &Self::Settings,
             _load_context: &mut LoadContext<'_>,
         ) -> Result<Self::Asset, Self::Error> {
+            struct SendOnDrop {
+                sender: crossbeam_channel::Sender<u32>,
+            }
+            impl Drop for SendOnDrop {
+                fn drop(&mut self) {
+                    let _ = self.sender.send(999);
+                }
+            }
+            let _on_drop = self
+                .finished_sender
+                .clone()
+                .map(|sender| SendOnDrop { sender });
+
             self.in_loader_sender.send_blocking(()).unwrap();
             let _ = self.gate_receiver.recv().await;
+            if let Some(finished_sender) = self.finished_sender.as_ref() {
+                finished_sender.send(1).unwrap();
+            }
             Ok(TestAsset)
         }
 
@@ -2271,11 +2291,13 @@ mod tests {
 
         let (in_loader_sender, in_loader_receiver) = async_channel::bounded(1);
         let (gate_sender, gate_receiver) = async_channel::bounded(1);
+        let (finished_sender, finished_receiver) = crossbeam_channel::bounded(1);
 
         app.init_asset::<TestAsset>()
             .register_asset_loader(GatedLoader {
                 in_loader_sender,
                 gate_receiver,
+                finished_sender: Some(finished_sender),
             });
 
         let path = Path::new("abc.ron");
@@ -2299,17 +2321,24 @@ mod tests {
 
         // Unblock the loader and then update a few times, showing that the asset never loads.
         gate_sender.send_blocking(()).unwrap();
-        for _ in 0..10 {
-            app.update();
-            for message in app
-                .world()
-                .resource::<Messages<AssetEvent<TestAsset>>>()
-                .iter_current_update_messages()
-            {
-                match message {
-                    AssetEvent::Unused { .. } => {}
-                    message => panic!("No asset events are allowed: {message:?}"),
-                }
+        let mut messages = vec![];
+        run_app_until(&mut app, |world| {
+            messages.extend(
+                world
+                    .resource::<Messages<AssetEvent<TestAsset>>>()
+                    .iter_current_update_messages(),
+            );
+            match finished_receiver.try_recv() {
+                Ok(999) => Some(()),
+                Ok(x) => panic!("only expected drop message, but got {x}"),
+                Err(TryRecvError::Empty) => None,
+                Err(TryRecvError::Disconnected) => panic!("cannot be disconnected"),
+            }
+        });
+        for message in messages {
+            match message {
+                AssetEvent::Unused { .. } => {}
+                message => panic!("No asset events are allowed: {message:?}"),
             }
         }
     }
@@ -2320,11 +2349,13 @@ mod tests {
 
         let (in_loader_sender, in_loader_receiver) = async_channel::bounded(1);
         let (gate_sender, gate_receiver) = async_channel::bounded(1);
+        let (finished_sender, finished_receiver) = crossbeam_channel::bounded(1);
 
         app.init_asset::<TestAsset>()
             .register_asset_loader(GatedLoader {
                 in_loader_sender,
                 gate_receiver,
+                finished_sender: Some(finished_sender),
             });
 
         let path = Path::new("abc.ron");
@@ -2350,17 +2381,24 @@ mod tests {
 
         // Unblock the loader and then update a few times, showing that the asset never loads.
         gate_sender.send_blocking(()).unwrap();
-        for _ in 0..10 {
-            app.update();
-            for message in app
-                .world()
-                .resource::<Messages<AssetEvent<TestAsset>>>()
-                .iter_current_update_messages()
-            {
-                match message {
-                    AssetEvent::Unused { .. } => {}
-                    message => panic!("No asset events are allowed: {message:?}"),
-                }
+        let mut messages = vec![];
+        run_app_until(&mut app, |world| {
+            messages.extend(
+                world
+                    .resource::<Messages<AssetEvent<TestAsset>>>()
+                    .iter_current_update_messages(),
+            );
+            match finished_receiver.try_recv() {
+                Ok(999) => Some(()),
+                Ok(x) => panic!("only expected drop message, but got {x}"),
+                Err(TryRecvError::Empty) => None,
+                Err(TryRecvError::Disconnected) => panic!("cannot be disconnected"),
+            }
+        });
+        for message in messages {
+            match message {
+                AssetEvent::Unused { .. } => {}
+                message => panic!("No asset events are allowed: {message:?}"),
             }
         }
     }
@@ -2933,6 +2971,7 @@ mod tests {
             .register_asset_loader(GatedLoader {
                 in_loader_sender,
                 gate_receiver,
+                finished_sender: None,
             })
             .register_asset_loader(AssetWithDepLoader);
 

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -4,8 +4,9 @@
 use crate::{
     io::Reader,
     meta::{loader_settings_meta_transform, MetaTransform, Settings},
-    Asset, AssetPath, ErasedAssetLoader, ErasedLoadedAsset, Handle, LoadContext, LoadDirectError,
-    LoadedAsset, LoadedUntypedAsset, RequestedHandleTypeMismatchError, UntypedHandle,
+    Asset, AssetPath, ErasedAssetIndex, ErasedAssetLoader, ErasedLoadedAsset, Handle, LoadContext,
+    LoadDirectError, LoadedAsset, LoadedUntypedAsset, RequestedHandleTypeMismatchError,
+    UntypedHandle,
 };
 use alloc::{borrow::ToOwned, boxed::Box, sync::Arc};
 use core::any::{type_name, TypeId};
@@ -129,10 +130,12 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
                 .asset_server
                 .get_or_create_path_handle(path, self.meta_transform)
         };
-        // `load_unknown_type_with_meta_transform` and `get_or_create_path_handle` always returns a
-        // Strong variant, so we are safe to unwrap.
-        let index = (&handle).try_into().unwrap();
-        self.load_context.dependencies.insert(index);
+        // `load_unknown_type_with_meta_transform` returns a default `Uuid` handle when it refuses
+        // to start the load, for example because the path is unapproved. There is no load to
+        // track as a dependency in that case, and the reason has already been logged.
+        if let Ok(index) = ErasedAssetIndex::try_from(&handle) {
+            self.load_context.dependencies.insert(index);
+        }
         handle
     }
 
@@ -246,10 +249,12 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
                 .asset_server
                 .get_or_create_path_handle_erased(path, type_id, type_name, self.meta_transform)
         };
-        // `load_with_meta_transform` and `get_or_create_path_handle` always returns a Strong
-        // variant, so we are safe to unwrap.
-        let index = (&handle).try_into().unwrap();
-        self.load_context.dependencies.insert(index);
+        // `load_with_meta_transform` returns a default `Uuid` handle when it refuses to start the
+        // load, for example because the path is unapproved. There is no load to track as a
+        // dependency in that case, and the reason has already been logged.
+        if let Ok(index) = ErasedAssetIndex::try_from(&handle) {
+            self.load_context.dependencies.insert(index);
+        }
         handle
     }
 

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -599,15 +599,17 @@ impl AssetServer {
             drop(guard);
         });
 
-        bevy_tasks::cfg::multi_threaded! {
+        let mut infos = bevy_tasks::cfg::multi_threaded! {
             if {
                 infos
-                    .pending_tasks
-                    .insert((&handle).try_into().unwrap(), task);
             } else {
-                task.detach();
+                // Pick the lock back up after the task got to run.
+                self.write_infos()
             }
-        }
+        };
+        infos
+            .pending_tasks
+            .insert((&handle).try_into().unwrap(), task);
     }
 
     /// Asynchronously load an asset that you do not know the type of statically. If you _do_ know the type of the asset,
@@ -699,13 +701,15 @@ impl AssetServer {
             drop(guard);
         });
 
-        bevy_tasks::cfg::multi_threaded! {
+        let mut infos = bevy_tasks::cfg::multi_threaded! {
             if {
-                infos.pending_tasks.insert(index, task);
+                infos
             } else {
-                task.detach();
+                // Pick the lock back up after the task got to run.
+                self.write_infos()
             }
-        }
+        };
+        infos.pending_tasks.insert(index, task);
 
         handle
     }
@@ -1113,13 +1117,15 @@ impl AssetServer {
             }
         });
 
-        bevy_tasks::cfg::multi_threaded! {
+        let mut infos = bevy_tasks::cfg::multi_threaded! {
             if {
-                infos.pending_tasks.insert(index, task);
+                infos
             } else {
-                task.detach();
+                // Pick the lock back up after the task got to run.
+                self.write_infos()
             }
-        }
+        };
+        infos.pending_tasks.insert(index, task);
 
         handle.typed_debug_checked()
     }
@@ -2233,11 +2239,17 @@ pub fn handle_internal_asset_events(world: &mut World) {
             server.reload_internal(path, true);
         }
 
-        bevy_tasks::cfg::multi_threaded! {
-            infos
-                .pending_tasks
-                .retain(|_, load_task| !load_task.is_finished());
-        }
+        let mut infos = bevy_tasks::cfg::multi_threaded! {
+            if {
+                infos
+            } else {
+                // Pick the lock back up after the task got to run.
+                server.write_infos()
+            }
+        };
+        infos
+            .pending_tasks
+            .retain(|_, load_task| !load_task.is_finished());
     });
 }
 

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -372,160 +372,6 @@ impl AssetServer {
         LoadBuilder::new(self)
     }
 
-    /// Same as [`load`](AssetServer::load), but you can load assets from unapproved paths
-    /// if [`AssetPlugin::unapproved_path_mode`](super::AssetPlugin::unapproved_path_mode)
-    /// is [`Deny`](UnapprovedPathMode::Deny).
-    ///
-    /// See [`UnapprovedPathMode`] and [`AssetPath::is_unapproved`]
-    #[deprecated(
-        note = "Use `asset_server.load_builder().override_unapproved().load(path)` instead"
-    )]
-    pub fn load_override<'a, A: Asset>(&self, path: impl Into<AssetPath<'a>>) -> Handle<A> {
-        self.load_builder().override_unapproved().load(path.into())
-    }
-
-    /// Same as [`load`](Self::load), but the type of the asset to load is specified by the runtime
-    /// `type_id`.
-    #[deprecated(note = "Use `asset_server.load_builder().load_erased(type_id, path)` instead")]
-    pub fn load_erased<'a>(
-        &self,
-        type_id: TypeId,
-        path: impl Into<AssetPath<'a>>,
-    ) -> UntypedHandle {
-        self.load_builder().load_erased(type_id, path.into())
-    }
-
-    /// Begins loading an [`Asset`] of type `A` stored at `path` while holding a guard item.
-    /// The guard item is dropped when either the asset is loaded or loading has failed.
-    ///
-    /// This function returns a "strong" [`Handle`]. When the [`Asset`] is loaded (and enters [`LoadState::Loaded`]), it will be added to the
-    /// associated [`Assets`] resource.
-    ///
-    /// The guard item should notify the caller in its [`Drop`] implementation. See example `multi_asset_sync`.
-    /// Synchronously this can be a [`Arc<AtomicU32>`] that decrements its counter, asynchronously this can be a `Barrier`.
-    /// This function only guarantees the asset referenced by the [`Handle`] is loaded. If your asset is separated into
-    /// multiple files, sub-assets referenced by the main asset might still be loading, depend on the implementation of the [`AssetLoader`].
-    ///
-    /// Additionally, you can check the asset's load state by reading [`AssetEvent`] events, calling [`AssetServer::load_state`], or checking
-    /// the [`Assets`] storage to see if the [`Asset`] exists yet.
-    ///
-    /// The asset load will fail and an error will be printed to the logs if the asset stored at `path` is not of type `A`.
-    #[deprecated(note = "Use `asset_server.load_builder().with_guard(guard).load(path)` instead")]
-    #[must_use = "not using the returned strong handle may result in the unexpected release of the asset"]
-    pub fn load_acquire<'a, A: Asset, G: Send + Sync + 'static>(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-        guard: G,
-    ) -> Handle<A> {
-        self.load_builder().with_guard(guard).load(path.into())
-    }
-
-    /// Same as [`load`](AssetServer::load_acquire), but you can load assets from unapproved paths
-    /// if [`AssetPlugin::unapproved_path_mode`](super::AssetPlugin::unapproved_path_mode)
-    /// is [`Deny`](UnapprovedPathMode::Deny).
-    ///
-    /// See [`UnapprovedPathMode`] and [`AssetPath::is_unapproved`]
-    #[deprecated(
-        note = "Use `asset_server.load_builder().with_guard(guard).override_unapproved().load(path)` instead"
-    )]
-    pub fn load_acquire_override<'a, A: Asset, G: Send + Sync + 'static>(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-        guard: G,
-    ) -> Handle<A> {
-        self.load_builder()
-            .with_guard(guard)
-            .override_unapproved()
-            .load(path.into())
-    }
-
-    /// Begins loading an [`Asset`] of type `A` stored at `path`. The given `settings` function will override the asset's
-    /// [`AssetLoader`] settings. The type `S` _must_ match the configured [`AssetLoader::Settings`] or `settings` changes
-    /// will be ignored and an error will be printed to the log.
-    #[deprecated(
-        note = "Use `asset_server.load_builder().with_settings(settings).load(path)` instead"
-    )]
-    #[must_use = "not using the returned strong handle may result in the unexpected release of the asset"]
-    pub fn load_with_settings<'a, A: Asset, S: Settings>(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-        settings: impl Fn(&mut S) + Send + Sync + 'static,
-    ) -> Handle<A> {
-        self.load_builder()
-            .with_settings(settings)
-            .load(path.into())
-    }
-
-    /// Same as [`load`](AssetServer::load_with_settings), but you can load assets from unapproved paths
-    /// if [`AssetPlugin::unapproved_path_mode`](super::AssetPlugin::unapproved_path_mode)
-    /// is [`Deny`](UnapprovedPathMode::Deny).
-    ///
-    /// See [`UnapprovedPathMode`] and [`AssetPath::is_unapproved`]
-    #[deprecated(
-        note = "Use `asset_server.load_builder().with_settings(settings).override_unapproved().load(path)` instead"
-    )]
-    pub fn load_with_settings_override<'a, A: Asset, S: Settings>(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-        settings: impl Fn(&mut S) + Send + Sync + 'static,
-    ) -> Handle<A> {
-        self.load_builder()
-            .with_settings(settings)
-            .override_unapproved()
-            .load(path.into())
-    }
-
-    /// Begins loading an [`Asset`] of type `A` stored at `path` while holding a guard item.
-    /// The guard item is dropped when either the asset is loaded or loading has failed.
-    ///
-    /// This function only guarantees the asset referenced by the [`Handle`] is loaded. If your asset is separated into
-    /// multiple files, sub-assets referenced by the main asset might still be loading, depend on the implementation of the [`AssetLoader`].
-    ///
-    /// The given `settings` function will override the asset's
-    /// [`AssetLoader`] settings. The type `S` _must_ match the configured [`AssetLoader::Settings`] or `settings` changes
-    /// will be ignored and an error will be printed to the log.
-    #[deprecated(
-        note = "Use `asset_server.load_builder().with_guard(guard).with_settings(settings).load(path)` instead"
-    )]
-    #[must_use = "not using the returned strong handle may result in the unexpected release of the asset"]
-    pub fn load_acquire_with_settings<'a, A: Asset, S: Settings, G: Send + Sync + 'static>(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-        settings: impl Fn(&mut S) + Send + Sync + 'static,
-        guard: G,
-    ) -> Handle<A> {
-        self.load_builder()
-            .with_guard(guard)
-            .with_settings(settings)
-            .load(path.into())
-    }
-
-    /// Same as [`load`](AssetServer::load_acquire_with_settings), but you can load assets from unapproved paths
-    /// if [`AssetPlugin::unapproved_path_mode`](super::AssetPlugin::unapproved_path_mode)
-    /// is [`Deny`](UnapprovedPathMode::Deny).
-    ///
-    /// See [`UnapprovedPathMode`] and [`AssetPath::is_unapproved`]
-    #[deprecated(
-        note = "Use `asset_server.load_builder().with_guard(guard).with_settings(settings).override_unapproved().load(path)` instead"
-    )]
-    pub fn load_acquire_with_settings_override<
-        'a,
-        A: Asset,
-        S: Settings,
-        G: Send + Sync + 'static,
-    >(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-        settings: impl Fn(&mut S) + Send + Sync + 'static,
-        guard: G,
-    ) -> Handle<A> {
-        self.load_builder()
-            .with_guard(guard)
-            .with_settings(settings)
-            .override_unapproved()
-            .load(path.into())
-    }
-
     pub(crate) fn load_with_meta_transform<'a, G: Send + Sync + 'static>(
         &self,
         path: impl Into<AssetPath<'a>>,
@@ -605,18 +451,6 @@ impl AssetServer {
 
         #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
         task.detach();
-    }
-
-    /// Asynchronously load an asset that you do not know the type of statically. If you _do_ know the type of the asset,
-    /// you should use [`AssetServer::load`]. If you don't know the type of the asset, but you can't use an async method,
-    /// consider using [`AssetServer::load_untyped`].
-    #[deprecated(note = "Use `asset_server.load_builder().load_untyped_async(path)` instead")]
-    #[must_use = "not using the returned strong handle may result in the unexpected release of the asset"]
-    pub async fn load_untyped_async<'a>(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-    ) -> Result<UntypedHandle, AssetLoadError> {
-        self.load_builder().load_untyped_async(path.into()).await
     }
 
     pub(crate) fn load_unknown_type_with_meta_transform<'a, G: Send + Sync + 'static>(
@@ -699,35 +533,6 @@ impl AssetServer {
         task.detach();
 
         handle
-    }
-
-    /// Load an asset without knowing its type. The method returns a handle to a [`LoadedUntypedAsset`].
-    ///
-    /// Once the [`LoadedUntypedAsset`] is loaded, an untyped handle for the requested path can be
-    /// retrieved from it.
-    ///
-    /// ```
-    /// use bevy_asset::{Assets, Handle, LoadedUntypedAsset};
-    /// use bevy_ecs::system::Res;
-    /// use bevy_ecs::resource::Resource;
-    ///
-    /// #[derive(Resource)]
-    /// struct LoadingUntypedHandle(Handle<LoadedUntypedAsset>);
-    ///
-    /// fn resolve_loaded_untyped_handle(loading_handle: Res<LoadingUntypedHandle>, loaded_untyped_assets: Res<Assets<LoadedUntypedAsset>>) {
-    ///     if let Some(loaded_untyped_asset) = loaded_untyped_assets.get(&loading_handle.0) {
-    ///         let handle = loaded_untyped_asset.handle.clone();
-    ///         // continue working with `handle` which points to the asset at the originally requested path
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// This indirection enables a non blocking load of an untyped asset, since I/O is
-    /// required to figure out the asset type before a handle can be created.
-    #[deprecated(note = "Use `asset_server.load_builder().load_untyped(path)` instead")]
-    #[must_use = "not using the returned strong handle may result in the unexpected release of the assets"]
-    pub fn load_untyped<'a>(&self, path: impl Into<AssetPath<'a>>) -> Handle<LoadedUntypedAsset> {
-        self.load_builder().load_untyped(path.into())
     }
 
     /// Performs an async asset load.
@@ -2020,7 +1825,7 @@ impl<'a> LoadBuilder<'a> {
 
     /// Asynchronously load an asset that you do not know the type of statically. If you _do_ know the type of the asset,
     /// you should use [`AssetServer::load`]. If you don't know the type of the asset, but you can't use an async method,
-    /// consider using [`AssetServer::load_untyped`].
+    /// consider using [`LoadBuilder::load_untyped`].
     #[must_use = "not using the returned strong handle may result in the unexpected release of the asset"]
     pub async fn load_untyped_async<'b>(
         self,

--- a/crates/bevy_camera_controller/Cargo.toml
+++ b/crates/bevy_camera_controller/Cargo.toml
@@ -24,6 +24,17 @@ bevy_transform = { path = "../bevy_transform", version = "0.20.0-dev", default-f
 bevy_window = { path = "../bevy_window", version = "0.20.0-dev", default-features = false }
 bevy_picking = { path = "../bevy_picking", version = "0.20.0-dev", default-features = false }
 
+bevy_derive = { path = "../bevy_derive", version = "0.20.0-dev" }
+bevy_platform = { path = "../bevy_platform", version = "0.20.0-dev" }
+bevy_image = { path = "../bevy_image", version = "0.20.0-dev" }
+bevy_render = { path = "../bevy_render", version = "0.20.0-dev" }
+bevy_color = { path = "../bevy_color", version = "0.20.0-dev" }
+
+bevy_asset = { version = "0.20.0-dev", path = "../bevy_asset", optional = true }
+bevy_core_pipeline = { version = "0.20.0-dev", path = "../bevy_core_pipeline", optional = true }
+bevy_gizmos = { version = "0.20.0-dev", path = "../bevy_gizmos", optional = true }
+
+
 [features]
 default = ["bevy_reflect"]
 bevy_reflect = ["dep:bevy_reflect"]
@@ -32,6 +43,16 @@ libm = ["bevy_math/libm"]
 # Camera controllers
 free_camera = []
 pan_camera = []
+pan_orbit_camera = []
+
+# PanOrbitCamera's extensions
+
+extension_anchor_indicator = ["pan_orbit_camera", "bevy_gizmos"]
+extension_independent_skybox = [
+  "pan_orbit_camera",
+  "bevy_asset",
+  "bevy_core_pipeline",
+]
 
 [lints]
 workspace = true

--- a/crates/bevy_camera_controller/src/lib.rs
+++ b/crates/bevy_camera_controller/src/lib.rs
@@ -36,8 +36,13 @@
 //! Each camera controller is stored in its own module,
 //! and gated behind a feature flag of the same name.
 
+extern crate alloc;
+
 #[cfg(feature = "free_camera")]
 pub mod free_camera;
 
 #[cfg(feature = "pan_camera")]
 pub mod pan_camera;
+
+#[cfg(feature = "pan_orbit_camera")]
+pub mod pan_orbit_camera;

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/component.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/component.rs
@@ -1,0 +1,733 @@
+//! The primary [`Component`] of the controller, [`PanOrbitCamera`].
+
+use std::{
+    f32::consts::{FRAC_PI_2, PI},
+    time::Duration,
+};
+
+use bevy_camera::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_log::prelude::*;
+use bevy_math::{dproj, prelude::*, DAffine3, DMat3, DMat4, DQuat, DVec2, DVec3};
+use bevy_platform::time::Instant;
+use bevy_time::prelude::*;
+use bevy_transform::prelude::*;
+
+use super::transform_utils::*;
+use bevy_window::RequestRedraw;
+
+use super::{
+    inputs::MotionInputs,
+    momentum::{Momentum, Velocity},
+    motion::CurrentMotion,
+    projections::{OrthographicSettings, PerspectiveSettings},
+    smoothing::{InputQueue, Smoothing},
+    zoom::ZoomLimits,
+};
+
+/// Tracks all state of a camera's controller, including its inputs, motion, and settings.
+///
+/// See the documentation on the contained fields and types to learn more about each setting.
+///
+/// # Moving the Camera
+///
+/// The [`PanOrbitCameraPlugin`](crate::pan_orbit_camera::DefaultPanOrbitCameraPlugins) will automatically handle sending inputs
+/// to the camera controller using [`bevy_picking`] to compute pointer hit locations for mouse,
+/// touch, and pen inputs. The picking plugin allows you to specify your own picking backend, or
+/// choose from a variety of provided backends. This is important because this camera controller
+/// relies on depth information for each pointer, and using the picking plugin means it can do this
+/// without forcing you into using a particular hit testing backend, e.g. raycasting, which is used
+/// by default.
+///
+/// To move the camera manually:
+///
+/// 1. Start a camera motion using one of [`PanOrbitCamera::start_orbit`],  [`PanOrbitCamera::start_pan`],
+///    [`PanOrbitCamera::start_zoom`].
+/// 2. While the motion should be active, send inputs with [`PanOrbitCamera::send_screenspace_input`] and
+///    [`PanOrbitCamera::send_zoom_input`].
+/// 3. When the motion should end, call  [`PanOrbitCamera::end_move`].
+#[derive(Debug, Clone, Component)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct PanOrbitCamera {
+    /// What input motions are currently allowed?
+    pub enabled_motion: EnabledMotion,
+    /// The type of camera orbit to use.
+    pub orbit_constraint: OrbitConstraint,
+    /// Set near and far zoom limits, as well as the ability to zoom through objects.
+    pub zoom_limits: ZoomLimits,
+    /// Input smoothing of camera motion.
+    pub smoothing: Smoothing,
+    /// Input sensitivity of the camera.
+    pub sensitivity: Sensitivity,
+    /// Amount of camera momentum after inputs have stopped.
+    pub momentum: Momentum,
+    /// How long should inputs attempting to start a new motion be ignored, after the last input
+    /// ends? This is useful to prevent accidentally killing momentum when, for example, releasing a
+    /// two finger right click on a trackpad triggers a scroll input.
+    pub input_debounce: Duration,
+    /// Settings used when the camera has a perspective [`Projection`].
+    pub perspective: PerspectiveSettings,
+    /// Settings used when the camera has an orthographic [`Projection`].
+    pub orthographic: OrthographicSettings,
+    /// Managed by the camera controller, though you may want to change this when spawning or
+    /// manually moving the camera.
+    ///
+    /// If the camera starts moving, but there is nothing under the pointer, the controller will
+    /// rotate, pan, and zoom about a point in the direction the camera is facing, at this depth.
+    /// This will be overwritten with the latest depth if a hit is found, to ensure the anchor point
+    /// doesn't change suddenly if the user moves the pointer away from an object.
+    pub last_anchor_depth: f64,
+    /// Current camera motion. Managed by the camera controller, but exposed publicly to allow for
+    /// overriding motion.
+    pub current_motion: CurrentMotion,
+}
+
+impl Default for PanOrbitCamera {
+    fn default() -> Self {
+        PanOrbitCamera {
+            orbit_constraint: Default::default(),
+            zoom_limits: Default::default(),
+            smoothing: Default::default(),
+            sensitivity: Default::default(),
+            momentum: Default::default(),
+            input_debounce: Duration::from_millis(80),
+            perspective: Default::default(),
+            orthographic: Default::default(),
+            enabled_motion: Default::default(),
+            current_motion: Default::default(),
+            last_anchor_depth: -2.0,
+        }
+    }
+}
+
+impl PanOrbitCamera {
+    /// Create a new editor camera component.
+    pub fn new(
+        orbit: OrbitConstraint,
+        smoothness: Smoothing,
+        sensitivity: Sensitivity,
+        momentum: Momentum,
+        initial_anchor_depth: f64,
+    ) -> Self {
+        Self {
+            orbit_constraint: orbit,
+            smoothing: smoothness,
+            sensitivity,
+            momentum,
+            last_anchor_depth: -initial_anchor_depth.abs(), // ensure depth is correct sign
+            ..Default::default()
+        }
+    }
+
+    /// Set the initial anchor depth of the camera controller.
+    pub fn with_initial_anchor_depth(self, initial_anchor_depth: f64) -> Self {
+        Self {
+            last_anchor_depth: -initial_anchor_depth.abs(), // ensure depth is correct sign
+            ..self
+        }
+    }
+
+    /// Gets the [`MotionInputs`], if the camera is being actively moved..
+    pub fn motion_inputs(&self) -> Option<&MotionInputs> {
+        match &self.current_motion {
+            CurrentMotion::Stationary | CurrentMotion::Momentum { .. } => None,
+            CurrentMotion::UserControlled { motion_inputs, .. } => Some(motion_inputs),
+        }
+    }
+
+    /// Returns the best guess at an anchor point if none is provided.
+    ///
+    /// Updates the fallback value with the latest hit. Ensures that if the camera starts orbiting
+    /// again and the pointer is not hitting anything, the anchor doesn't suddenly change distance.
+    /// This is what would happen if we used a fixed value.
+    fn maybe_update_anchor(&mut self, anchor: Option<DVec3>) -> DVec3 {
+        let validate_anchor =
+            |anchor: &DVec3| anchor.length() >= f32::EPSILON as f64 && anchor.is_finite();
+
+        let z_last = -self.last_anchor_depth.abs();
+        let fallback = anchor
+            .filter(|a| a.is_finite())
+            .map(|mut anchor| {
+                anchor.z = z_last;
+                anchor
+            })
+            .filter(validate_anchor)
+            .unwrap_or(DVec3::new(0.0, 0.0, z_last));
+
+        let anchor = anchor.filter(validate_anchor).unwrap_or(fallback);
+
+        self.last_anchor_depth = anchor.z;
+        anchor
+    }
+
+    /// Get the position of the anchor in the camera's view space.
+    pub fn anchor_view_space(&self) -> Option<DVec3> {
+        if let CurrentMotion::UserControlled { anchor, .. } = &self.current_motion {
+            Some(*anchor)
+        } else {
+            None
+        }
+    }
+
+    /// Get the position of the anchor in world space.
+    pub fn anchor_world_space(&self, camera_transform: &GlobalTransform) -> Option<DVec3> {
+        self.anchor_view_space().map(|anchor_view_space| {
+            camera_transform
+                .to_matrix()
+                .as_dmat4()
+                .transform_point3(anchor_view_space)
+        });
+
+        self.anchor_view_space().map(|anchor_view_space| {
+            let (_, r, t) = camera_transform.to_scale_rotation_translation();
+            r.as_dquat() * anchor_view_space + t.as_dvec3()
+        })
+    }
+
+    /// Should the camera controller prevent new motions from starting because the user is actively
+    /// operating the camera?
+    ///
+    /// This does not consider zooming as "actively controlled". This is needed because scroll input
+    /// devices often have their own momentum and can continue to provide values even when the user
+    /// is not actively providing inputs. Like a scroll wheel that keeps spinning or a trackpad
+    /// with smooth scrolling. Without this, the controller will feel unresponsive, as a user will
+    /// be unable to initiate a new motion even though they are not technically providing an input.
+    pub fn is_actively_controlled(&self) -> bool {
+        !self.current_motion.is_zooming_only()
+            && (self.current_motion.is_user_controlled()
+                || self
+                    .current_motion
+                    .momentum_duration()
+                    .map(|duration| duration < self.input_debounce)
+                    .unwrap_or(false))
+    }
+
+    /// Call this to start an orbiting motion with the optionally supplied anchor position in view
+    /// space. See [`PanOrbitCamera`] for usage.
+    pub fn start_orbit(&mut self, anchor: Option<DVec3>) {
+        if !self.enabled_motion.orbit {
+            return;
+        }
+        self.current_motion = CurrentMotion::UserControlled {
+            anchor: self.maybe_update_anchor(anchor),
+            motion_inputs: MotionInputs::OrbitZoom {
+                screenspace_inputs: InputQueue::default(),
+                zoom_inputs: InputQueue::default(),
+            },
+        }
+    }
+
+    /// Call this to start a panning motion with the optionally supplied anchor position in view
+    /// space. See [`PanOrbitCamera`] for usage.
+    pub fn start_pan(&mut self, anchor: Option<DVec3>) {
+        if !self.enabled_motion.pan {
+            return;
+        }
+        self.current_motion = CurrentMotion::UserControlled {
+            anchor: self.maybe_update_anchor(anchor),
+            motion_inputs: MotionInputs::PanZoom {
+                screenspace_inputs: InputQueue::default(),
+                zoom_inputs: InputQueue::default(),
+            },
+        }
+    }
+
+    /// Call this to start a zooming motion with the optionally supplied anchor position in view
+    /// space. See [`PanOrbitCamera`] for usage.
+    pub fn start_zoom(&mut self, anchor: Option<DVec3>) {
+        if !self.enabled_motion.zoom {
+            return;
+        }
+        let anchor = self.maybe_update_anchor(anchor);
+
+        // Inherit current camera velocity
+        let zoom_inputs = match self.current_motion {
+            CurrentMotion::Stationary | CurrentMotion::Momentum { .. } => InputQueue::default(),
+            CurrentMotion::UserControlled {
+                ref mut motion_inputs,
+                ..
+            } => InputQueue(motion_inputs.zoom_inputs_mut().0.drain(..).collect()),
+        };
+        self.current_motion = CurrentMotion::UserControlled {
+            anchor,
+            motion_inputs: MotionInputs::Zoom { zoom_inputs },
+        }
+    }
+
+    /// Send screen space camera inputs. This will be interpreted as panning or orbiting depending
+    /// on the current motion. See [`PanOrbitCamera`] for usage.
+    pub fn send_screenspace_input(&mut self, screenspace_input: Vec2) {
+        if let CurrentMotion::UserControlled {
+            ref mut motion_inputs,
+            ..
+        } = self.current_motion
+        {
+            match motion_inputs {
+                MotionInputs::OrbitZoom {
+                    screenspace_inputs: movement,
+                    ..
+                } => movement.process_input(screenspace_input, self.smoothing.orbit),
+                MotionInputs::PanZoom {
+                    screenspace_inputs: movement,
+                    ..
+                } => movement.process_input(screenspace_input, self.smoothing.pan),
+                MotionInputs::Zoom { .. } => (), // When in zoom-only, we ignore pan and zoom
+            }
+        }
+    }
+
+    /// Send zoom inputs. See [`PanOrbitCamera`] for usage.
+    pub fn send_zoom_input(&mut self, zoom_amount: f32) {
+        if let CurrentMotion::UserControlled { motion_inputs, .. } = &mut self.current_motion {
+            motion_inputs
+                .zoom_inputs_mut()
+                .process_input(zoom_amount, self.smoothing.zoom);
+        }
+    }
+
+    /// End the current camera motion, allowing other motions on this camera to begin. See
+    /// [`PanOrbitCamera`] for usage.
+    pub fn end_move(&mut self) {
+        let velocity = match self.current_motion {
+            CurrentMotion::Stationary | CurrentMotion::Momentum { .. } => return,
+            CurrentMotion::UserControlled {
+                anchor,
+                ref motion_inputs,
+                ..
+            } => match motion_inputs {
+                MotionInputs::OrbitZoom { .. } => Velocity::Orbit {
+                    anchor,
+                    velocity: motion_inputs.orbit_momentum(self.momentum.init_orbit),
+                },
+                MotionInputs::PanZoom { .. } => Velocity::Pan {
+                    anchor,
+                    velocity: motion_inputs.pan_momentum(self.momentum.init_pan),
+                },
+                MotionInputs::Zoom { .. } => Velocity::None,
+            },
+        };
+        let momentum_start = Instant::now();
+        self.current_motion = CurrentMotion::Momentum {
+            velocity,
+            momentum_start,
+        };
+    }
+
+    /// Called once every frame to compute motions and update the transforms of all [`PanOrbitCamera`]s
+    pub fn update_camera_positions(
+        mut camera_set: ParamSet<(
+            Query<(&Transform, Entity), With<PanOrbitCamera>>,
+            Query<(&mut PanOrbitCamera, &Camera, Mut<Projection>)>,
+            Query<&mut Transform, With<PanOrbitCamera>>,
+        )>,
+        mut event: MessageWriter<RequestRedraw>,
+        time: Res<Time>,
+    ) {
+        camera_set
+            .p0()
+            .iter()
+            .filter_map(|(transform, entity)| {
+                read_transform(transform).map(|transform| (entity, transform))
+            })
+            .collect::<Vec<_>>()
+            .iter()
+            .filter_map(|(entity, (original_translation, original_rotation))| {
+                camera_set
+                    .p1()
+                    .get_mut(*entity)
+                    .ok()
+                    .and_then(|(mut camera_controller, camera, projection)| {
+                        let dt = time.delta();
+                        camera_controller.update_transform_and_projection(
+                            camera,
+                            original_translation,
+                            original_rotation,
+                            projection,
+                            &mut event,
+                            dt,
+                        )
+                    })
+                    .map(|transform| (*entity, transform))
+            })
+            .collect::<Vec<_>>()
+            .iter()
+            .for_each(|(entity, (delta_translation, delta_rotation))| {
+                if let Ok(mut entity_mut) = camera_set.p2().get_mut(*entity) {
+                    apply_delta(&mut entity_mut, *delta_translation, *delta_rotation);
+                }
+            });
+    }
+
+    /// Update this [`PanOrbitCamera`]'s transform and projection.
+    pub fn update_transform_and_projection(
+        &mut self,
+        camera: &Camera,
+        original_translation: &DVec3,
+        original_rotation: &DQuat,
+        mut projection: Mut<Projection>,
+        redraw: &mut MessageWriter<RequestRedraw>,
+        delta_time: Duration,
+    ) -> Option<(DVec3, DQuat)> {
+        let mut new_translation = *original_translation;
+        let mut new_rotation = *original_rotation;
+        let (anchor, orbit, pan, zoom) = match &mut self.current_motion {
+            CurrentMotion::Stationary => return None,
+            CurrentMotion::Momentum { velocity, .. } => {
+                velocity.decay(self.momentum, delta_time);
+                match velocity {
+                    Velocity::None => {
+                        self.current_motion = CurrentMotion::Stationary;
+                        return None;
+                    }
+                    Velocity::Orbit { anchor, velocity } => (anchor, *velocity, DVec2::ZERO, 0.0),
+                    Velocity::Pan { anchor, velocity } => (anchor, DVec2::ZERO, *velocity, 0.0),
+                }
+            }
+            CurrentMotion::UserControlled {
+                anchor,
+                motion_inputs,
+            } => (
+                anchor,
+                motion_inputs.smooth_orbit_velocity() * self.sensitivity.orbit.as_dvec2(),
+                motion_inputs.smooth_pan_velocity(),
+                motion_inputs.smooth_zoom_velocity() * self.sensitivity.zoom as f64,
+            ),
+        };
+
+        // If there is no motion, we will have already early-exited.
+        redraw.write(RequestRedraw);
+
+        let screen_to_view_space_at_depth =
+            |perspective: &PerspectiveProjection, depth: f64| -> Option<DVec2> {
+                let target_size = camera.logical_viewport_size()?.as_dvec2();
+                // This is a strange-looking, but key part of the otherwise normal-looking
+                // screen-to-view transformation. What we are trying to do here is answer "if we
+                // move by one pixel in x and y, how much distance do we cover in the world at the
+                // specified depth?" Because the viewport position's origin is in the corner, we
+                // need to halve the target size and subtract one pixel. This gets us a viewport
+                // position one pixel diagonal offset from the center of the screen.
+                let mut viewport_position = target_size / 2.0 - 1.0;
+                // Flip the y-coordinate origin from the top to the bottom.
+                viewport_position.y = target_size.y - viewport_position.y;
+                let ndc = viewport_position * 2. / target_size - DVec2::ONE;
+
+                let ndc_to_view = dproj::perspective_infinite_reverse(
+                    perspective.fov as f64,
+                    perspective.aspect_ratio as f64,
+                    perspective.near as f64,
+                )
+                .inverse(); // f64 version replaced .get_projection_matrix().as_dmat4().inverse();
+
+                let view_near_plane = ndc_to_view.project_point3(ndc.extend(1.));
+                // Using EPSILON because an NDC with Z = 0 returns NaNs.
+                let view_far_plane = ndc_to_view.project_point3(ndc.extend(f64::EPSILON));
+                let direction = view_far_plane - view_near_plane;
+                let depth_normalized_direction = direction / direction.z;
+                let view_pos3 = depth_normalized_direction * depth;
+                let view_pos = view_pos3.truncate();
+                if !view_pos.is_finite() || view_pos3.z != depth {
+                    #[cfg(debug_assertions)]
+                    error!("Invalid view position {view_pos:?} from depth {depth}");
+                    return None;
+                }
+                Some(view_pos)
+            };
+
+        let view_offset = match projection.as_ref() {
+            Projection::Perspective(perspective) => {
+                let Some(offset) = screen_to_view_space_at_depth(perspective, anchor.z) else {
+                    error!("Malformed camera");
+                    return None;
+                };
+                offset
+            }
+            Projection::Orthographic(ortho) => DVec2::new(-ortho.scale as f64, ortho.scale as f64),
+            Projection::Custom(_) => {
+                error_once!("Custom projections are not supported.");
+                return None;
+            }
+        };
+
+        let pan_translation_view_space = (pan * view_offset).extend(0.0);
+
+        let size_at_anchor =
+            super::zoom::length_per_pixel_at_view_space_pos(camera, *anchor).unwrap_or(0.0);
+
+        // I'm not sure why I created this mapping - maybe it was to prevent zooming through
+        // surfaces if the user really whipped the mouse:
+        //
+        // let zoom_unscaled = (zoom.abs() / 60.0)
+        //     .powf(1.3); // Varies from 0 to 1 over x = [0..inf]
+        // let zoom_input = (1.0 - 1.0 / (zoom_unscaled + 1.0)) * zoom.signum();
+        //
+        // It is roughly equivalent to just using
+        // let zoom_input = zoom * 0.01;
+        //
+        // ...so I've opted to just factor this constant out of the other scaling constants below.
+        //
+        // I recall spending a lot of time on this mapping function, but for the life of me can't
+        // remember why. Leaving this comment behind for a few releases, delete me if nothing
+        // breaks.
+
+        // The zoom input, bounded to prevent zooming past the limits.
+        let zoom_bounded = if size_at_anchor <= self.zoom_limits.min_size_per_pixel {
+            zoom.min(0.0) // Prevent zooming in further
+        } else if size_at_anchor >= self.zoom_limits.max_size_per_pixel {
+            zoom.max(0.0) // Prevent zooming out further
+        } else {
+            zoom
+        };
+
+        let zoom_translation_view_space = match &mut *projection {
+            Projection::Perspective(perspective) => {
+                let zoom_amount = if self.zoom_limits.zoom_through_objects {
+                    // Clamp the zoom speed at the limits
+                    zoom * size_at_anchor.clamp(
+                        self.zoom_limits.min_size_per_pixel,
+                        self.zoom_limits.max_size_per_pixel,
+                    )
+                } else {
+                    // If we cannot zoom through objects, use the bounded input
+                    zoom_bounded * size_at_anchor
+                };
+                // Scale this with the perspective FOV, so the zoom speed feels the same regardless.
+                anchor.normalize() * zoom_amount / perspective.fov as f64
+            }
+            Projection::Orthographic(ortho) => {
+                // Constants are hand-tuned to feel equivalent between perspective and ortho. Might
+                // be a better way to do this correctly if it matters.
+                ortho.scale *= 1.0 - zoom_bounded as f32 * 0.0015;
+                // We don't move the camera in z, as this is managed by another ortho system.
+                anchor.normalize()
+                    * zoom_bounded
+                    * anchor.z.abs()
+                    * 0.0015
+                    * DVec3::new(1.0, 1.0, 0.0)
+            }
+            Projection::Custom(_) => {
+                error_once!("Custom projections are not supported.");
+                return None;
+            }
+        };
+
+        // If we can zoom through objects, then scoot the anchor point forward when we hit the
+        // limit. This prevents the anchor from getting closer to the camera than the minimum
+        // distance, or worse, zooming past the anchor.
+        if self.zoom_limits.zoom_through_objects
+            && size_at_anchor < self.zoom_limits.min_size_per_pixel
+            && matches!(*projection, Projection::Perspective(_))
+            && zoom > 0.0
+        {
+            *anchor += zoom_translation_view_space;
+        }
+
+        new_translation +=
+            new_rotation * (pan_translation_view_space + zoom_translation_view_space);
+
+        *anchor -= pan_translation_view_space + zoom_translation_view_space;
+
+        let orbit = orbit * DVec2::new(-1.0, 1.0);
+        let anchor_world = DMat4::from_rotation_translation(new_rotation, new_translation)
+            .transform_point3(*anchor);
+        let orbit_dir = orbit.normalize().extend(0.0);
+        let orbit_axis_world = new_rotation
+            .mul_vec3(orbit_dir.cross(DVec3::NEG_Z).normalize())
+            .normalize();
+
+        let orbit_multiplier = 0.005;
+        if orbit.is_finite() && orbit.length() != 0.0 {
+            match self.orbit_constraint {
+                OrbitConstraint::Fixed { up, can_pass_tdc } => {
+                    let epsilon = 1e-3;
+                    let motion_threshold = 1e-5;
+
+                    let angle_to_bdc = cam_forward(new_rotation).angle_between(up);
+                    let angle_to_tdc = cam_forward(new_rotation).angle_between(-up);
+                    let pitch_angle = {
+                        let desired_rotation = orbit.y * orbit_multiplier;
+                        if can_pass_tdc {
+                            desired_rotation
+                        } else if desired_rotation >= 0.0 {
+                            desired_rotation.min(angle_to_tdc - (epsilon as f64).min(angle_to_tdc))
+                        } else {
+                            desired_rotation.max(-angle_to_bdc + (epsilon as f64).min(angle_to_bdc))
+                        }
+                    };
+                    let pitch = if pitch_angle.abs() <= motion_threshold {
+                        DQuat::IDENTITY
+                    } else {
+                        DQuat::from_axis_angle(cam_left(new_rotation), pitch_angle)
+                    };
+
+                    let yaw_angle = orbit.x * orbit_multiplier;
+                    let yaw = if yaw_angle.abs() <= motion_threshold {
+                        DQuat::IDENTITY
+                    } else {
+                        DQuat::from_axis_angle(up, yaw_angle)
+                    };
+
+                    match [pitch == DQuat::IDENTITY, yaw == DQuat::IDENTITY] {
+                        [true, true] => (),
+                        [true, false] => rotate_around(
+                            (&mut new_translation, &mut new_rotation),
+                            anchor_world,
+                            yaw,
+                        ),
+                        [false, true] => rotate_around(
+                            (&mut new_translation, &mut new_rotation),
+                            anchor_world,
+                            pitch,
+                        ),
+                        [false, false] => rotate_around(
+                            (&mut new_translation, &mut new_rotation),
+                            anchor_world,
+                            yaw * pitch,
+                        ),
+                    };
+
+                    let how_upright = cam_up(new_rotation).angle_between(up).abs() as f32;
+                    // Orient the camera so up always points up (roll).
+                    let forward = cam_forward(new_rotation);
+                    if how_upright > epsilon && how_upright < FRAC_PI_2 - epsilon {
+                        new_rotation = look_to(forward, up);
+                    } else if how_upright > FRAC_PI_2 + epsilon && how_upright < PI - epsilon {
+                        new_rotation = look_to(forward, -up);
+                    }
+                }
+                OrbitConstraint::Free => {
+                    let rotation =
+                        DQuat::from_axis_angle(orbit_axis_world, orbit.length() * orbit_multiplier);
+                    rotate_around(
+                        (&mut new_translation, &mut new_rotation),
+                        anchor_world,
+                        rotation,
+                    );
+                }
+            }
+        }
+
+        self.last_anchor_depth = anchor.z;
+        let (_, delta_rotation, delta_translation) = {
+            let original =
+                DAffine3::from_rotation_translation(*original_rotation, *original_translation);
+            let new = DAffine3::from_rotation_translation(new_rotation, new_translation);
+            (original.inverse() * new).to_scale_rotation_translation()
+        };
+        Some((delta_translation, delta_rotation))
+    }
+
+    /// Compute the world space size of a pixel at the anchor.
+    ///
+    /// This is a robust alternative to using the distance of the camera from the anchor point.
+    /// Camera distance is not directly related to how large something is on screen - that depends
+    /// on the camera projection.
+    ///
+    /// This function correctly accounts for camera projection and is particularly useful when
+    /// doing zoom and scale calculations.
+    pub fn length_per_pixel_at_anchor(&self, camera: &Camera) -> Option<f64> {
+        let anchor_view = self.anchor_view_space()?;
+        super::zoom::length_per_pixel_at_view_space_pos(camera, anchor_view)
+    }
+
+    /// The last known anchor depth. This value will always be negative.
+    pub fn last_anchor_depth(&self) -> f64 {
+        -self.last_anchor_depth.abs()
+    }
+}
+
+/// A 64-bit version of `Transform::rotate_around`
+pub fn rotate_around(transform: (&mut DVec3, &mut DQuat), point: DVec3, rotation: DQuat) {
+    *transform.0 = point + rotation * (*transform.0 - point);
+    *transform.1 = (rotation * *transform.1).normalize();
+}
+
+/// A 64-bit version of `Transform::look_to`. Returns the rotation quaternion for the given
+/// facing direction and up vector.
+pub fn look_to(direction: DVec3, up: DVec3) -> DQuat {
+    let back = -direction;
+    let right = up
+        .cross(back)
+        .try_normalize()
+        .unwrap_or_else(|| up.any_orthogonal_vector());
+    let up = back.cross(right);
+    DQuat::from_mat3(&DMat3::from_cols(right, up, back))
+}
+
+/// Helper method for getting a local forward vector
+pub fn cam_forward(cam_rotation: DQuat) -> DVec3 {
+    cam_rotation * DVec3::NEG_Z
+}
+/// Helper method for getting a local left vector
+pub fn cam_left(cam_rotation: DQuat) -> DVec3 {
+    cam_rotation * DVec3::NEG_X
+}
+/// Helper method for getting a local up vector
+pub fn cam_up(cam_rotation: DQuat) -> DVec3 {
+    cam_rotation * DVec3::Y
+}
+
+/// Settings that define how camera orbit behaves.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum OrbitConstraint {
+    /// The camera's up direction is fixed.
+    Fixed {
+        /// The camera's up direction must always be parallel with this unit vector.
+        up: DVec3,
+        /// Should the camera be allowed to pass over top dead center (TDC), making the camera
+        /// upside down compared to the up direction?
+        can_pass_tdc: bool,
+    },
+    /// The camera's up direction is free.
+    Free,
+}
+
+impl Default for OrbitConstraint {
+    fn default() -> Self {
+        Self::Fixed {
+            up: DVec3::Y,
+            can_pass_tdc: false,
+        }
+    }
+}
+
+/// The sensitivity of the camera controller to inputs.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct Sensitivity {
+    /// X/Y sensitivity of orbit inputs, multiplied.
+    pub orbit: Vec2,
+    /// Sensitivity of zoom inputs, multiplied.
+    pub zoom: f32,
+}
+
+impl Default for Sensitivity {
+    fn default() -> Self {
+        Self {
+            orbit: Vec2::splat(1.0),
+            zoom: 1.0,
+        }
+    }
+}
+
+/// Controls what kinds of motions are allowed to initiate. Does not affect momentum.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct EnabledMotion {
+    /// Should pan be enabled?
+    pub pan: bool,
+    /// Should orbit be enabled?
+    pub orbit: bool,
+    /// Should zoom be enabled?
+    pub zoom: bool,
+}
+
+impl Default for EnabledMotion {
+    fn default() -> Self {
+        Self {
+            pan: true,
+            orbit: true,
+            zoom: true,
+        }
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/inputs.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/inputs.rs
@@ -1,0 +1,153 @@
+//! Defines mutually exclusive camera input motions, and a place to store these input streams.
+
+use std::time::Duration;
+
+use super::smoothing::InputQueue;
+use bevy_math::{prelude::*, DVec2};
+
+/// Tracks the current exclusive motion type and input queue of the camera controller.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum MotionInputs {
+    /// The camera can orbit and zoom
+    OrbitZoom {
+        /// A queue of screenspace orbiting inputs; usually the mouse drag vector.
+        screenspace_inputs: InputQueue<Vec2>,
+        /// A queue of zoom inputs.
+        zoom_inputs: InputQueue<f32>,
+    },
+    /// The camera can pan and zoom
+    PanZoom {
+        /// A queue of screenspace panning inputs; usually the mouse drag vector.
+        screenspace_inputs: InputQueue<Vec2>,
+        /// A queue of zoom inputs.
+        zoom_inputs: InputQueue<f32>,
+    },
+    /// The camera can only zoom
+    Zoom {
+        /// A queue of zoom inputs.
+        zoom_inputs: InputQueue<f32>,
+    },
+}
+
+impl MotionInputs {
+    /// The motion-conserving smoothed orbit velocity in screen space.
+    pub fn smooth_orbit_velocity(&self) -> DVec2 {
+        if let Self::OrbitZoom {
+            screenspace_inputs, ..
+        } = self
+        {
+            let value = screenspace_inputs
+                .latest_smoothed()
+                .unwrap_or(Vec2::ZERO)
+                .as_dvec2();
+            if value.is_finite() {
+                value
+            } else {
+                DVec2::ZERO
+            }
+        } else {
+            DVec2::ZERO
+        }
+    }
+
+    /// The motion-conserving smoothed pan velocity in screen space.
+    pub fn smooth_pan_velocity(&self) -> DVec2 {
+        if let Self::PanZoom {
+            screenspace_inputs, ..
+        } = self
+        {
+            let value = screenspace_inputs
+                .latest_smoothed()
+                .unwrap_or(Vec2::ZERO)
+                .as_dvec2();
+            if value.is_finite() {
+                value
+            } else {
+                DVec2::ZERO
+            }
+        } else {
+            DVec2::ZERO
+        }
+    }
+
+    /// Approximate orbit velocity over the last `window`. to use for momentum calculations.
+    pub fn orbit_momentum(&self, window: Duration) -> DVec2 {
+        if let Self::OrbitZoom {
+            screenspace_inputs, ..
+        } = self
+        {
+            let velocity = screenspace_inputs.average_smoothed_value(window).as_dvec2();
+            if !velocity.is_finite() {
+                DVec2::ZERO
+            } else {
+                velocity
+            }
+        } else {
+            DVec2::ZERO
+        }
+    }
+
+    /// Approximate pan velocity over the last `window`. to use for momentum calculations.
+    pub fn pan_momentum(&self, window: Duration) -> DVec2 {
+        if let Self::PanZoom {
+            screenspace_inputs, ..
+        } = self
+        {
+            let velocity = screenspace_inputs.average_smoothed_value(window).as_dvec2();
+            if !velocity.is_finite() {
+                DVec2::ZERO
+            } else {
+                velocity
+            }
+        } else {
+            DVec2::ZERO
+        }
+    }
+
+    /// Motion-conserving smoothed zoom input velocity.
+    pub fn smooth_zoom_velocity(&self) -> f64 {
+        let velocity = self.zoom_inputs().latest_smoothed().unwrap_or(0.0) as f64;
+        if !velocity.is_finite() {
+            0.0
+        } else {
+            velocity
+        }
+    }
+
+    /// Get a reference to the queue of zoom inputs.
+    pub fn zoom_inputs(&self) -> &InputQueue<f32> {
+        match self {
+            MotionInputs::OrbitZoom { zoom_inputs, .. }
+            | MotionInputs::PanZoom { zoom_inputs, .. }
+            | MotionInputs::Zoom { zoom_inputs } => zoom_inputs,
+        }
+    }
+
+    /// Get a mutable reference to the queue of zoom inputs.
+    pub fn zoom_inputs_mut(&mut self) -> &mut InputQueue<f32> {
+        match self {
+            MotionInputs::OrbitZoom { zoom_inputs, .. }
+            | MotionInputs::PanZoom { zoom_inputs, .. }
+            | MotionInputs::Zoom { zoom_inputs } => zoom_inputs,
+        }
+    }
+
+    /// Approximate smoothed  absolute value of the zoom velocity over the last `window`.
+    pub fn zoom_velocity_abs(&self, window: Duration) -> f64 {
+        let zoom_inputs = match self {
+            MotionInputs::OrbitZoom { zoom_inputs, .. }
+            | MotionInputs::PanZoom { zoom_inputs, .. }
+            | MotionInputs::Zoom { zoom_inputs } => zoom_inputs,
+        };
+
+        let velocity = zoom_inputs.approx_smoothed(window, |v| {
+            *v = v.abs();
+        }) as f64;
+        if !velocity.is_finite() {
+            0.0
+        } else {
+            velocity
+        }
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/mod.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/mod.rs
@@ -1,0 +1,37 @@
+//! Camera controller implementation.
+
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+
+pub mod component;
+pub mod inputs;
+pub mod momentum;
+pub mod motion;
+pub mod projections;
+pub mod smoothing;
+pub mod transform_utils;
+pub mod zoom;
+
+/// Adds [`PanOrbitCamera`](crate::pan_orbit_camera::prelude::component::PanOrbitCamera) functionality without an input plugin or any extensions. This
+/// requires an input plugin to function! If you don't use the [`crate::pan_orbit_camera::input::DefaultInputPlugin`],
+/// you will need to provide your own.
+pub struct MinimalPanOrbitCameraPlugin;
+
+impl Plugin for MinimalPanOrbitCameraPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PreUpdate,
+            (
+                component::PanOrbitCamera::update_camera_positions,
+                projections::update_orthographic,
+                // Technically `update_perspective` does not alter the camera
+                // position, but the other two systems above do, so I'm putting
+                // them all in the SyncCameraPosition group.
+                projections::update_perspective,
+            )
+                .chain()
+                .after(bevy_picking::PickingSystems::Last)
+                .in_set(crate::pan_orbit_camera::SyncCameraPosition),
+        );
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/momentum.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/momentum.rs
@@ -1,0 +1,103 @@
+//! Provides the [`Momentum`] settings.
+
+use std::time::Duration;
+
+use bevy_math::{DVec2, DVec3};
+
+/// Defines momentum behavior of this [`super::component::PanOrbitCamera`].
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct Momentum {
+    /// Momentum decay scales with velocity.
+    pub pan_damping: u8,
+    /// Momentum decay is constant.
+    pub pan_friction: f64,
+    /// The sampling window to use when a movement ends to determine the velocity of the camera when
+    /// momentum decay begins. The higher this value, the easier it is to "flick" the camera, but
+    /// the more of a velocity discontinuity will be present when momentum starts.
+    pub init_pan: Duration,
+    /// Momentum decay scales with velocity.
+    pub orbit_damping: u8,
+    /// Momentum decay is constant.
+    pub orbit_friction: f64,
+    /// The sampling window to use when a movement ends to determine the velocity of the camera when
+    /// momentum decay begins. The higher this value, the easier it is to "flick" the camera, but
+    /// the more of a velocity discontinuity will be present when momentum starts.
+    pub init_orbit: Duration,
+}
+
+impl Default for Momentum {
+    fn default() -> Self {
+        Self {
+            pan_damping: 160,
+            pan_friction: 0.2,
+            init_pan: Duration::from_millis(40),
+            orbit_damping: 160,
+            orbit_friction: 0.2,
+            init_orbit: Duration::from_millis(60),
+        }
+    }
+}
+
+impl Momentum {
+    fn decay_velocity_orbit(self, velocity: DVec2, delta_time: Duration) -> DVec2 {
+        let speed = velocity.length();
+        let f_damping = self.orbit_damping as f64 / 256.0 * speed * 10.0;
+        let f_friction = self.orbit_friction * 40.0;
+        let braking = (f_damping + f_friction) * delta_time.as_secs_f64();
+        (speed - braking).max(0.0) * velocity.normalize_or_zero()
+    }
+
+    fn decay_velocity_pan(self, velocity: DVec2, delta_time: Duration) -> DVec2 {
+        let speed = velocity.length();
+        let f_damping = self.pan_damping as f64 / 256.0 * speed * 10.0;
+        let f_friction = self.pan_friction * 40.0;
+        let braking = (f_damping + f_friction) * delta_time.as_secs_f64();
+        (speed - braking).max(0.0) * velocity.normalize_or_zero()
+    }
+}
+
+/// The velocity of the camera.
+#[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum Velocity {
+    /// The velocity is zero and the camera will transition into the Stationary state.
+    #[default]
+    None,
+    ///Camera is spinning.
+    Orbit {
+        /// The anchor of rotation being orbited about.
+        anchor: DVec3,
+        /// The current velocity of the camera about the anchor.
+        velocity: DVec2,
+    },
+    /// Camera is sliding.
+    Pan {
+        /// The anchor point that should stick to the pointer during panning.
+        anchor: DVec3,
+        /// The current panning velocity of the camera.
+        velocity: DVec2,
+    },
+}
+
+impl Velocity {
+    const DECAY_THRESHOLD: f64 = 1e-3;
+    /// Decay the velocity based on the momentum setting.
+    pub fn decay(&mut self, momentum: Momentum, delta_time: Duration) {
+        let is_none = match self {
+            Velocity::None => true,
+            Velocity::Orbit { velocity, .. } => {
+                *velocity = momentum.decay_velocity_orbit(*velocity, delta_time);
+                velocity.length() <= Self::DECAY_THRESHOLD
+            }
+            Velocity::Pan { velocity, .. } => {
+                *velocity = momentum.decay_velocity_pan(*velocity, delta_time);
+                velocity.length() <= Self::DECAY_THRESHOLD
+            }
+        };
+
+        if is_none {
+            *self = Velocity::None;
+        }
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/motion.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/motion.rs
@@ -1,0 +1,108 @@
+//! The motion state of the camera.
+
+use std::time::Duration;
+
+use super::{inputs::MotionInputs, momentum::Velocity};
+use bevy_math::DVec3;
+use bevy_platform::time::Instant;
+
+/// The current motion state of the camera.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum CurrentMotion {
+    /// The camera is not moving.
+    #[default]
+    Stationary,
+    /// The camera is in motion, but not being directly controlled by the user. This happens while
+    /// the camera has momentum.
+    Momentum {
+        /// Contains inherited velocity, if any. This will decay based on momentum settings.
+        velocity: Velocity,
+        /// Used to compute how long the camera has been in the momentum state. Useful for
+        /// debouncing user inputs.
+        momentum_start: Instant,
+    },
+    /// The camera is being directly controlled by the user.
+    UserControlled {
+        /// The point the camera is rotating about, zooming into, or panning with, in view space
+        /// (relative to the camera).
+        ///
+        /// - Rotation: the direction of the anchor does not change, it is fixed in screenspace.
+        /// - Panning: the depth of the anchor does not change, the camera only moves in x and y.
+        /// - Zoom: the direction of the anchor does not change, but the length does.
+        anchor: DVec3,
+        /// Pan and orbit are mutually exclusive, however both can be used with zoom.
+        motion_inputs: MotionInputs,
+    },
+}
+
+impl CurrentMotion {
+    /// Returns `true` if the camera is moving due to inputs or momentum.
+    pub fn is_moving(&self) -> bool {
+        !matches!(self, CurrentMotion::Stationary)
+            && !matches!(
+                self,
+                CurrentMotion::Momentum {
+                    velocity: Velocity::None,
+                    ..
+                }
+            )
+    }
+
+    /// Returns `true` if the camera is moving due to user inputs.
+    pub fn is_user_controlled(&self) -> bool {
+        matches!(self, CurrentMotion::UserControlled { .. })
+    }
+
+    /// Get the user motion inputs if they exist.
+    pub fn inputs(&self) -> Option<&MotionInputs> {
+        match self {
+            CurrentMotion::Stationary | CurrentMotion::Momentum { .. } => None,
+            CurrentMotion::UserControlled { motion_inputs, .. } => Some(motion_inputs),
+        }
+    }
+
+    /// Returns true if the camera is user controlled and orbiting.
+    pub fn is_orbiting(&self) -> bool {
+        matches!(
+            self,
+            Self::UserControlled {
+                motion_inputs: MotionInputs::OrbitZoom { .. },
+                ..
+            }
+        )
+    }
+
+    /// Returns true if the camera is user controlled and panning.
+    pub fn is_panning(&self) -> bool {
+        matches!(
+            self,
+            Self::UserControlled {
+                motion_inputs: MotionInputs::PanZoom { .. },
+                ..
+            }
+        )
+    }
+
+    /// Returns true if the camera is user controlled and only zooming.
+    pub fn is_zooming_only(&self) -> bool {
+        matches!(
+            self,
+            Self::UserControlled {
+                motion_inputs: MotionInputs::Zoom { .. },
+                ..
+            }
+        )
+    }
+
+    /// How long has the camera been moving with momentum, without user input? This is equivalent to
+    /// the amount of time since the last input event ended.
+    pub fn momentum_duration(&self) -> Option<Duration> {
+        match self {
+            CurrentMotion::Momentum { momentum_start, .. } => {
+                Some(Instant::now().saturating_duration_since(*momentum_start))
+            }
+            _ => None,
+        }
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/projections.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/projections.rs
@@ -1,0 +1,143 @@
+//! Configurable options for the challenge of working with orthographic cameras.
+
+use bevy_camera::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_math::{DQuat, DVec3};
+use bevy_transform::components::Transform;
+
+use crate::pan_orbit_camera::prelude::*;
+
+use self::motion::CurrentMotion;
+
+/// Settings used when the [`PanOrbitCamera`] has a perspective [`Projection`].
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct PerspectiveSettings {
+    /// Limits the near clipping plane to always fit inside this range.
+    ///
+    /// The camera controller will try to make the near clipping plane smaller when you zoom in to
+    /// ensure the anchor (the thing you are zooming into) is always within the view frustum
+    /// (visible), bounded by this limit.
+    ///
+    /// Unless the camera is zoomed very close to something, it will spend most of the time at the
+    /// high end of this limit - you should treat that like the default near clipping plane. Bevy
+    /// defaults to `0.1`, and you should probably use that too unless you have a very good reason
+    /// not to. Many rendering effects that rely on depth can break down if the clipping plane is
+    /// very far from `0.1`.
+    pub near_clip_limits: std::ops::Range<f32>,
+    /// When computing the near plane position, the anchor depth is multiplied by this value to
+    /// determine the new near clip position. This should be smaller than one, to ensure that the
+    /// object you are looking at, which will be located at the anchor position, is bot being
+    /// clipped. Some parts of the object may protrude toward the camera, which is what necessitates
+    /// this.
+    pub near_clip_multiplier: f32,
+}
+
+impl Default for PerspectiveSettings {
+    fn default() -> Self {
+        Self {
+            near_clip_limits: 1e-9..f32::INFINITY,
+            near_clip_multiplier: 0.05,
+        }
+    }
+}
+
+/// Updates perspective projection properties of editor cameras.
+pub fn update_perspective(mut cameras: Query<(&PanOrbitCamera, Mut<Projection>)>) {
+    for (editor_cam, mut projection) in cameras.iter_mut() {
+        let Projection::Perspective(ref mut perspective) = *projection else {
+            continue;
+        };
+        let limits = editor_cam.perspective.near_clip_limits.clone();
+        let multiplier = editor_cam.perspective.near_clip_multiplier;
+        perspective.near = (editor_cam.last_anchor_depth.abs() as f32 * multiplier)
+            .clamp(limits.start, limits.end);
+    }
+}
+
+/// Settings used when the [`PanOrbitCamera`] has an orthographic [`Projection`].
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct OrthographicSettings {
+    /// The camera's near clipping plane will move closer and farther from the anchor point during
+    /// zoom to maximize precision. The position of the near plane is based on the orthographic
+    /// projection `scale`, multiplied by this value.
+    ///
+    /// To maximize depth precision, make this as small ap possible. If the value is too large,
+    /// depth-based effects like SSAO will break down. If the value is too small, objects that
+    /// should be visible will be clipped. Ideally, the clipping planes should scale with the scene
+    /// geometry and camera frustum to tightly bound the visible scene, but this is not yet
+    /// implemented.
+    pub scale_to_near_clip: f32,
+    /// Limits the distance the near clip plane can be to the anchor. The low limit is useful to
+    /// prevent geometry clipping when zooming in, while the high limit is useful to prevent the
+    /// camera moving too far away from the anchor, causing precision issues.
+    pub near_clip_limits: std::ops::Range<f32>,
+    /// The far plane is placed opposite the anchor from the near plane, at this multiple of the
+    /// distance from the near plane to the anchor. Setting this to 1.0 means the camera frustum is
+    /// centered on the anchor. It might be desirable to make this larger to prevent things in the
+    /// background from disappearing when zooming in.
+    pub far_clip_multiplier: f32,
+}
+
+impl Default for OrthographicSettings {
+    fn default() -> Self {
+        Self {
+            scale_to_near_clip: 1_000_000.0,
+            near_clip_limits: 1.0..1_000_000.0,
+            far_clip_multiplier: 1.0,
+        }
+    }
+}
+
+/// Update the ortho camera projection and position based on the [`OrthographicSettings`].
+pub fn update_orthographic(
+    mut camera_set: ParamSet<(
+        Query<(Entity, &mut PanOrbitCamera, Mut<Projection>)>,
+        Query<&mut Transform, With<PanOrbitCamera>>,
+    )>,
+) {
+    camera_set
+        .p0()
+        .iter_mut()
+        .filter_map(|(entity, mut editor_cam, mut projection)| {
+            if let Projection::Orthographic(ref mut orthographic) = *projection {
+                let mut delta_translation = DVec3::ZERO;
+                let anchor_dist = editor_cam.last_anchor_depth().abs() as f32;
+                let target_dist = (editor_cam.orthographic.scale_to_near_clip * orthographic.scale)
+                    .clamp(
+                        editor_cam.orthographic.near_clip_limits.start,
+                        editor_cam.orthographic.near_clip_limits.end,
+                    );
+
+                let forward_amount = anchor_dist - target_dist;
+                let cam_forward = DVec3::NEG_Z;
+                let movement = cam_forward * forward_amount as f64;
+
+                if movement != DVec3::ZERO {
+                    delta_translation += movement;
+                }
+
+                editor_cam.last_anchor_depth += forward_amount as f64;
+                if let CurrentMotion::UserControlled { ref mut anchor, .. } =
+                    editor_cam.current_motion
+                {
+                    anchor.z += forward_amount as f64;
+                }
+
+                orthographic.near = 0.0;
+                orthographic.far =
+                    anchor_dist * (1.0 + editor_cam.orthographic.far_clip_multiplier);
+                Some((entity, delta_translation))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .iter()
+        .for_each(|(entity, delta_translation)| {
+            if let Ok(mut cam_transform) = camera_set.p1().get_mut(*entity) {
+                apply_delta(&mut cam_transform, *delta_translation, DQuat::IDENTITY);
+            }
+        });
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/smoothing.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/smoothing.rs
@@ -1,0 +1,197 @@
+//! Implements a motion-conserving smoothed input queue.
+
+use alloc::collections::VecDeque;
+
+use std::{
+    ops::{Add, AddAssign, Mul},
+    time::Duration,
+};
+
+use bevy_derive::{Deref, DerefMut};
+use bevy_platform::time::Instant;
+
+/// How smooth should inputs be? Over what tine window should they be averaged.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct Smoothing {
+    /// Smoothing window for panning.
+    pub pan: Duration,
+    /// Smoothing window for orbit.
+    pub orbit: Duration,
+    /// Smoothing window for zoom.
+    pub zoom: Duration,
+}
+
+impl Default for Smoothing {
+    fn default() -> Self {
+        Smoothing {
+            pan: Duration::from_millis(10),
+            orbit: Duration::from_millis(30),
+            zoom: Duration::from_millis(60),
+        }
+    }
+}
+
+/// A smoothed queue of inputs over time.
+///
+/// Useful for smoothing to query "what was the average input over the last N milliseconds?". This
+/// does some important bookkeeping to ensure samples are not over or under sampled. This means the
+/// queue has very useful properties:
+///
+/// 1. The smoothing can change over time, useful for sampling over changing framerates.
+/// 2. The sum of smoothed and unsmoothed inputs will be equal despite (1). This is useful because
+///    you can smooth something like pointer motions, and the smoothed output will arrive at the
+///    same destination as the unsmoothed input without drifting.
+#[derive(Debug, Clone, Deref, DerefMut)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct InputQueue<T>(pub VecDeque<InputStreamEntry<T>>);
+
+/// Represents a single input in an [`InputQueue`].
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct InputStreamEntry<T> {
+    /// The time the sample was added and smoothed value computed.
+    time: Instant,
+    /// The input sample recorded at this time.
+    sample: T,
+    /// How much of this entry is available to be consumed, from `0.0` to `1.0`. This is required to
+    /// ensure that smoothing does not over or under sample any entries as the size of the sampling
+    /// window changes. This value should always be zero by the time a sample exits the queue.
+    fraction_remaining: f32,
+    /// Because we need to do bookkeeping to ensure no samples are under or over sampled, we compute
+    /// the smoothed value at the same time a sample is inserted. Because consumers of this will
+    /// want to read the smoothed samples multiple times, we do the computation eagerly so the input
+    /// stream is always in a valid state, and the act of a user reading a sample multiple times
+    /// does not change the value they get.
+    smoothed_value: T,
+}
+
+impl<T: Copy + Default + Add<Output = T> + AddAssign<T> + Mul<f32, Output = T>> Default
+    for InputQueue<T>
+{
+    fn default() -> Self {
+        let start = Instant::now();
+        let interval = Duration::from_secs_f32(1.0 / 60.0);
+        let mut queue = VecDeque::default();
+        for time in
+            // See: https://github.com/aevyrie/bevy_editor_cam/issues/13 There is no guarantee that
+            // `start` is large enough to subtract from, so we ignore any subtractions that fail, to
+            // avoid a panic. If this fails, it will manifest as a slight stutter, most noticeable
+            // during zooming. However, this *should* only happen at the very startup of the app,
+            // and even then, is unlikely.
+            (1..Self::MAX_EVENTS)
+                .filter_map(|i| start.checked_sub(interval.mul_f32(i as f32)))
+        {
+            queue.push_back(InputStreamEntry {
+                time,
+                sample: T::default(),
+                fraction_remaining: 1.0,
+                smoothed_value: T::default(),
+            });
+        }
+        Self(queue)
+    }
+}
+
+impl<T: Copy + Default + Add<Output = T> + AddAssign<T> + Mul<f32, Output = T>> InputQueue<T> {
+    const MAX_EVENTS: usize = 256;
+
+    /// Add an input sample to the queue, and compute the smoothed value.
+    ///
+    /// The smoothing must be computed at the time a sample is added to ensure no samples are over
+    /// or under sampled in the smoothing process.
+    pub fn process_input(&mut self, new_input: T, smoothing: Duration) {
+        let now = Instant::now();
+        let queue = &mut self.0;
+
+        // Compute the expected sampling window end index
+        let window_size = queue
+            .iter()
+            .enumerate()
+            .find(|(_i, entry)| now.duration_since(entry.time) > smoothing)
+            .map(|(i, _)| i) // `find` breaks *after* we fail, so we don't need to add one
+            .unwrap_or(0)
+            + 1; // Add one to account for the new sample being added
+
+        let range_end = (window_size - 1).clamp(0, queue.len());
+
+        // Compute the smoothed value by sampling over the desired window
+        let target_fraction = 1.0 / window_size as f32;
+        let mut smoothed_value = new_input * target_fraction;
+        for entry in queue.range_mut(..range_end) {
+            // Only consume what is left of a sample, to prevent oversampling
+            let this_fraction = entry.fraction_remaining.min(target_fraction);
+            smoothed_value += entry.sample * this_fraction;
+            entry.fraction_remaining = (entry.fraction_remaining - this_fraction).max(0.0);
+        }
+
+        // To prevent under sampling, we also need to look at entries older than the window, and add
+        // those to the smoothed value, to catch up. This happens when the window shrinks, or there
+        // is a pause in rendering and it needs to catch up.
+        for old_entry in queue
+            .range_mut(range_end..)
+            .filter(|e| e.fraction_remaining > 0.0)
+        {
+            smoothed_value += old_entry.sample * old_entry.fraction_remaining;
+            old_entry.fraction_remaining = 0.0;
+        }
+
+        queue.truncate(Self::MAX_EVENTS - 1);
+        queue.push_front(InputStreamEntry {
+            time: now,
+            sample: new_input,
+            fraction_remaining: 1.0 - target_fraction,
+            smoothed_value,
+        });
+    }
+
+    /// Get the latest motion-conserving smoothed input value.
+    pub fn latest_smoothed(&self) -> Option<T> {
+        self.iter_smoothed().next().map(|(_, val)| val)
+    }
+
+    /// Iterator over all smoothed samples.
+    pub fn iter_smoothed(&self) -> impl Iterator<Item = (Instant, T)> + '_ {
+        self.0
+            .iter()
+            .map(|entry| (entry.time, entry.smoothed_value))
+    }
+
+    /// Iterate over the raw samples.
+    pub fn iter_unsmoothed(&self) -> impl Iterator<Item = (Instant, T)> + '_ {
+        self.0.iter().map(|entry| (entry.time, entry.sample))
+    }
+
+    /// Approximate the smoothed average sampled in the `window`.
+    pub fn average_smoothed_value(&self, window: Duration) -> T {
+        let now = Instant::now();
+        let mut count = 0;
+        let sum = self
+            .iter_smoothed()
+            .filter(|(t, _)| now.duration_since(*t) < window)
+            .map(|(_, smoothed_value)| smoothed_value)
+            .reduce(|acc, v| {
+                count += 1;
+                acc + v
+            })
+            .unwrap_or_default();
+        sum * (1.0 / count as f32)
+    }
+
+    /// Approximate smoothed value with user-supplied modifier function as needed
+    pub fn approx_smoothed(&self, window: Duration, mut modifier: impl FnMut(&mut T)) -> T {
+        let now = Instant::now();
+        let n_elements = &mut 0;
+        self.iter_unsmoothed()
+            .filter(|(time, _)| now.duration_since(*time) < window)
+            .map(|(_, value)| {
+                *n_elements += 1;
+                let mut value = value;
+                modifier(&mut value);
+                value
+            })
+            .reduce(|acc, v| acc + v)
+            .unwrap_or_default()
+            * (1.0 / *n_elements as f32)
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/transform_utils.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/transform_utils.rs
@@ -1,0 +1,19 @@
+//! Utilities to manipulate on Transform.
+
+use bevy_math::{DQuat, DVec3};
+use bevy_transform::prelude::*;
+
+/// Read the translation and rotation of an entity.
+pub fn read_transform(cam_transform: &Transform) -> Option<(DVec3, DQuat)> {
+    Some((
+        cam_transform.translation.as_dvec3(),
+        cam_transform.rotation.as_dquat(),
+    ))
+}
+
+/// Apply a movement delta to an entity.
+pub fn apply_delta(cam_transform: &mut Transform, delta_translation: DVec3, delta_rotation: DQuat) {
+    let delta_transform = Transform::from_translation(delta_translation.as_vec3())
+        .with_rotation(delta_rotation.as_quat());
+    *cam_transform = cam_transform.mul_transform(delta_transform);
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/zoom.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/zoom.rs
@@ -1,0 +1,94 @@
+//! Provides [`ZoomLimits`] settings.
+
+use bevy_camera::prelude::*;
+use bevy_math::{DVec2, DVec3};
+
+/// Bound zooming scale, and define behavior at the limits of zoom.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct ZoomLimits {
+    /// The smallest size in world space units of a pixel located at the anchor when zooming in.
+    ///
+    /// When zooming in, a single pixel will cover a smaller and smaller world space area. This
+    /// limit will set how small of an area a single pixel can cover. Assuming you are using meters,
+    /// setting this to 1e-3 would limit the camera zoom so that an object that is one millimeter
+    /// across and located at the anchor would take up at most a single pixel.
+    ///
+    /// Setting this to a small value will let you zoom in further. If this is too small, you may
+    /// begin to encounter floating point rendering errors.
+    pub min_size_per_pixel: f64,
+    /// The largest size in world space units of a pixel located at the anchor when zooming out.
+    ///
+    /// When zooming out, a single pixel will cover a larger and larger world space area. This limit
+    /// will set how large of an area a single pixel can cover. Assuming you are using meters,
+    /// setting this to 1.0 would only allow you to zoom out until a 1 meter object located at the
+    /// anchor  was the size of a pixel.
+    ///
+    /// Setting this to a large value will let you zoom out further.
+    pub max_size_per_pixel: f64,
+    /// When true, and when a perspective projection is being used, zooming in can pass through
+    /// objects. When reaching `min_size_per_pixel`, instead of stopping, the camera will continue
+    /// moving forward, passing through the object in front of the camera.
+    ///
+    /// Additionally, when reaching `max_size_per_pixel`, the camera does not continue zooming out,
+    /// but instead continues at the same speed.
+    pub zoom_through_objects: bool,
+}
+
+impl Default for ZoomLimits {
+    fn default() -> Self {
+        Self {
+            min_size_per_pixel: 1e-6, // Any smaller and floating point rendering artifacts appear.
+            max_size_per_pixel: 1e27, // The diameter of the observable universe is probably a good upper limit.
+            zoom_through_objects: false,
+        }
+    }
+}
+
+/// The size of a pixel at the anchor (under the pointer) in world space units.
+///
+/// This is a much better way to compute scale than using camera distance from the anchor (the
+/// length of the anchor vector). Anchor distance does not take camera projection into account.
+pub fn length_per_pixel_at_view_space_pos(camera: &Camera, view_space_pos: DVec3) -> Option<f64> {
+    // This is a point offset by scaled_offset units to the right relative to the camera facing the
+    // anchor point. We can then project the anchor and the offset anchor onto the viewport
+    // (screen), to see how many pixels apart these two points are on screen. This gives us the
+    // world units per pixel, at the anchor (pointer) location.
+    //
+    // The scaled_offset is important for handling varying scales. If we only offset by a unit value
+    // (1.0), then at large distances, an offset of 1.0 would round to 0.0 when projected on the
+    // screen, and the result, a reciprocal, would go to infinity. To combat this, we ensure that
+    // our offset is a similar scale to the anchor distance itself, and cancel it out later.
+    let scaled_offset = view_space_pos.length();
+    let view_space_pos_offset = view_space_pos + DVec3::X * scaled_offset;
+
+    let viewport_pos = view_to_viewport(camera, view_space_pos)?;
+    let viewport_pos_offset = view_to_viewport(camera, view_space_pos_offset)?;
+
+    let pixels_per_world_unit = (viewport_pos_offset - viewport_pos).length();
+    // The length per pixel is the inverse of pixels_per_world_unit
+    let len_per_pixel = pixels_per_world_unit.recip().min(f64::MAX) * scaled_offset;
+    len_per_pixel.is_finite().then_some(len_per_pixel)
+}
+
+/// Project a point in view space onto the camera's viewport.
+fn view_to_viewport(camera: &Camera, view_space_point: DVec3) -> Option<DVec2> {
+    let ndc_space_coords = camera
+        .clip_from_view()
+        .as_dmat4()
+        .project_point3(view_space_point);
+
+    // NDC z-values outside of 0 < z < 1 are outside the (implicit) camera frustum and are thus not
+    // in viewport-space
+    let ndc_space_coords =
+        (!ndc_space_coords.is_nan() && ndc_space_coords.z >= 0.0 && ndc_space_coords.z <= 1.0)
+            .then_some(ndc_space_coords)?;
+
+    let target_size = camera.logical_viewport_size()?.as_dvec2();
+
+    // Once in NDC space, we can discard the z element and rescale x/y to fit the screen
+    let mut viewport_position = (ndc_space_coords.truncate() + DVec2::ONE) / 2.0 * target_size;
+    // Flip the Y co-ordinate origin from the bottom to the top.
+    viewport_position.y = target_size.y - viewport_position.y;
+    Some(viewport_position)
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/anchor_indicator.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/anchor_indicator.rs
@@ -1,0 +1,109 @@
+//! A `pan_orbit_camera` extension that draws an indicator in the scene at the location of the
+//! anchor. This makes it more obvious to users what point in space the camera is rotating around,
+//! making it easier to use and understand.
+
+use crate::pan_orbit_camera::prelude::*;
+
+use bevy_app::prelude::*;
+use bevy_camera::prelude::*;
+use bevy_color::Color;
+use bevy_ecs::prelude::*;
+use bevy_gizmos::prelude::*;
+use bevy_math::prelude::*;
+use bevy_transform::prelude::*;
+
+/// See the [module](self) docs.
+pub struct AnchorIndicatorPlugin;
+
+impl Plugin for AnchorIndicatorPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            draw_anchor
+                .after(TransformSystems::Propagate)
+                .after(bevy_camera::CameraUpdateSystems),
+        );
+    }
+}
+
+/// Optional. Configures whether or not an [`PanOrbitCamera`] should show an anchor indicator when the
+/// camera is orbiting. The indicator will be enabled if this component is not present.
+#[derive(Debug, Component)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct AnchorIndicator {
+    /// Should the indicator be visible on this camera?
+    pub enabled: bool,
+}
+
+impl Default for AnchorIndicator {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+/// Use gizmos to draw the camera anchor in world space.
+pub fn draw_anchor(
+    cameras: Query<(
+        &PanOrbitCamera,
+        &GlobalTransform,
+        &Camera,
+        Option<&AnchorIndicator>,
+    )>,
+    mut gizmos: Gizmos,
+) {
+    for (editor_cam, cam_transform, cam, _) in cameras
+        .iter()
+        .filter(|(.., anchor_indicator)| anchor_indicator.map(|a| a.enabled).unwrap_or(true))
+    {
+        let Some(anchor_world) = editor_cam.anchor_world_space(cam_transform) else {
+            continue;
+        };
+        let p1 = cam
+            .world_to_viewport(cam_transform, anchor_world.as_vec3())
+            .unwrap_or_default();
+        let p2 = cam
+            .world_to_viewport(
+                cam_transform,
+                anchor_world.as_vec3() + cam_transform.right().as_vec3(),
+            )
+            .unwrap_or_default();
+
+        let scale = 8.0 / (p2 - p1).length();
+
+        // Shift the indicator toward the camera to prevent it clipping objects near parallel
+        let shift = (cam_transform.translation() - anchor_world.as_vec3()).normalize() * scale;
+        let anchor_world = anchor_world.as_vec3() + shift;
+
+        if editor_cam.current_motion.is_orbiting() {
+            let gizmo_color = || Color::WHITE;
+            let arm_length = 0.4;
+
+            gizmos.circle(
+                Isometry3d::new(anchor_world, cam_transform.rotation()),
+                scale,
+                gizmo_color(),
+            );
+            let offset = 1.5 * scale;
+            gizmos.ray(
+                anchor_world + offset * cam_transform.left(),
+                offset * arm_length * cam_transform.left(),
+                gizmo_color(),
+            );
+            gizmos.ray(
+                anchor_world + offset * cam_transform.right(),
+                offset * arm_length * cam_transform.right(),
+                gizmo_color(),
+            );
+            gizmos.ray(
+                anchor_world + offset * cam_transform.up(),
+                offset * arm_length * cam_transform.up(),
+                gizmo_color(),
+            );
+            gizmos.ray(
+                anchor_world + offset * cam_transform.down(),
+                offset * arm_length * cam_transform.down(),
+                gizmo_color(),
+            );
+        }
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/dolly_zoom.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/dolly_zoom.rs
@@ -1,0 +1,297 @@
+//! A `pan_orbit_camera` extension that adds the ability to smoothly transition between perspective
+//! and orthographic projections using what's known as a "dolly zoom" in film. This is useful
+//! because it ensures that the object the user is focusing on does not change size even as the
+//! projection changes.
+
+use std::time::Duration;
+
+use bevy_app::prelude::*;
+use bevy_camera::{prelude::*, ScalingMode};
+use bevy_ecs::prelude::*;
+use bevy_log::error_once;
+use bevy_math::{prelude::*, DQuat, DVec3};
+use bevy_platform::{collections::HashMap, time::Instant};
+use bevy_transform::components::Transform;
+use bevy_window::RequestRedraw;
+
+use crate::pan_orbit_camera::{
+    controller::transform_utils::apply_delta,
+    prelude::{motion::CurrentMotion, EnabledMotion, PanOrbitCamera},
+};
+
+/// See the [module](self) docs.
+pub struct DollyZoomPlugin;
+
+impl Plugin for DollyZoomPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<DollyZoom>()
+            .add_message::<DollyZoomTrigger>()
+            .add_systems(
+                PreUpdate,
+                DollyZoom::update.before(PanOrbitCamera::update_camera_positions),
+            )
+            .add_systems(Last, DollyZoomTrigger::receive); // This mutates camera components, so we want to be sure it runs *after* rendering has happened. We place it in Last to ensure that we wake the next frame if needed. If we run this in PostUpdate, this can result in rendering artifacts because this will mutate projections right before rendering.
+    }
+}
+
+/// Used when transitioning from ortho to perspective, this needs to be close to ortho (zero fov).
+const ZERO_FOV: f64 = 1e-3;
+
+/// Triggers a dolly zoom on the specified camera.
+#[derive(Debug, Message)]
+pub struct DollyZoomTrigger {
+    /// The new projection.
+    pub target_projection: Projection,
+    /// The camera to update.
+    pub camera: Entity,
+}
+
+impl DollyZoomTrigger {
+    fn receive(
+        mut events: MessageReader<Self>,
+        mut state: ResMut<DollyZoom>,
+        mut camera_set: ParamSet<(
+            Query<(&Camera, Mut<Projection>, &mut PanOrbitCamera)>,
+            Query<&mut Transform, With<PanOrbitCamera>>,
+        )>,
+        mut redraw: MessageWriter<RequestRedraw>,
+    ) {
+        for event in events.read() {
+            let mut cameras = camera_set.p0();
+            let Ok((camera, mut proj, mut controller)) = cameras.get_mut(event.camera) else {
+                continue;
+            };
+            let mut delta_translation = DVec3::ZERO;
+            redraw.write(RequestRedraw);
+            let (fov_start, triangle_base) = match &*proj {
+                Projection::Perspective(perspective) => {
+                    if let Projection::Perspective(PerspectiveProjection {
+                        fov: target_fov, ..
+                    }) = event.target_projection
+                    {
+                        // If the target and current fov are the same, there is nothing to do.
+                        if (target_fov - perspective.fov).abs() <= f32::EPSILON {
+                            continue;
+                        }
+                    }
+                    (
+                        perspective.fov,
+                        (perspective.fov as f64 / 2.0).tan() * controller.last_anchor_depth.abs(),
+                    )
+                }
+                Projection::Orthographic(ortho) => {
+                    if matches!(event.target_projection, Projection::Orthographic(..)) {
+                        // If the camera is in ortho, and wants to go to ortho, early exit.
+                        continue;
+                    }
+
+                    let base = ortho.scale as f64 / ortho_tri_base_to_scale_factor(camera, ortho);
+                    let new_anchor_dist = base / (ZERO_FOV / 2.0).tan();
+                    let forward_dist = controller.last_anchor_depth.abs() - new_anchor_dist;
+                    let cam_forward = DVec3::NEG_Z;
+                    let next_translation = cam_forward * forward_dist;
+
+                    delta_translation += next_translation;
+                    controller.last_anchor_depth += forward_dist;
+
+                    (ZERO_FOV as f32, base)
+                }
+                Projection::Custom(_) => {
+                    error_once!("Custom projections are not supported.");
+                    return;
+                }
+            };
+
+            let perspective_start = PerspectiveProjection {
+                fov: fov_start,
+                ..Default::default()
+            };
+            *proj = Projection::Perspective(perspective_start.clone());
+
+            state
+                .map
+                .entry(event.camera)
+                .and_modify(|e| {
+                    e.perspective_start = perspective_start.clone();
+                    e.proj_end = event.target_projection.clone();
+                    e.triangle_base = triangle_base;
+                    e.start = Instant::now();
+                    e.complete = false;
+                })
+                .or_insert(ZoomEntry {
+                    perspective_start,
+                    proj_end: event.target_projection.clone(),
+                    triangle_base,
+                    start: Instant::now(),
+                    initial_enabled: controller.enabled_motion.clone(),
+                    complete: false,
+                });
+
+            controller.end_move();
+            controller.current_motion = CurrentMotion::Stationary;
+            controller.enabled_motion = EnabledMotion {
+                pan: false,
+                orbit: false,
+                zoom: false,
+            };
+
+            let mut camera_muts = camera_set.p1();
+            let mut camera_mut = camera_muts.get_mut(event.camera).unwrap();
+            apply_delta(&mut camera_mut, delta_translation, DQuat::IDENTITY);
+        }
+    }
+}
+
+struct ZoomEntry {
+    perspective_start: PerspectiveProjection,
+    proj_end: Projection,
+    triangle_base: f64,
+    start: Instant,
+    initial_enabled: EnabledMotion,
+    complete: bool,
+}
+
+/// Stores settings and state for the dolly zoom plugin.
+#[derive(Resource)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct DollyZoom {
+    /// The duration of the dolly zoom transition animation.
+    pub animation_duration: Duration,
+    /// The cubic curve used to animate the camera during a dolly zoom.
+    #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
+    pub animation_curve: CubicSegment<Vec2>,
+    #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
+    map: HashMap<Entity, ZoomEntry>,
+}
+
+impl Default for DollyZoom {
+    fn default() -> Self {
+        Self {
+            animation_duration: Duration::from_millis(300),
+            animation_curve: CubicSegment::new_bezier_easing((0.65, 0.0), (0.35, 1.0)),
+            map: Default::default(),
+        }
+    }
+}
+
+impl DollyZoom {
+    fn update(
+        mut state: ResMut<Self>,
+        mut camera_set: ParamSet<(
+            Query<(&Camera, Mut<Projection>, &mut PanOrbitCamera)>,
+            Query<&mut Transform, With<PanOrbitCamera>>,
+        )>,
+        mut redraw: MessageWriter<RequestRedraw>,
+    ) {
+        let animation_duration = state.animation_duration;
+        let animation_curve = state.animation_curve;
+        for (
+            camera_entity,
+            ZoomEntry {
+                perspective_start,
+                proj_end,
+                triangle_base,
+                start,
+                initial_enabled,
+                complete,
+            },
+        ) in state.map.iter_mut()
+        {
+            let mut cameras = camera_set.p0();
+            let Ok((camera, mut projection, mut controller)) = cameras.get_mut(*camera_entity)
+            else {
+                *complete = true;
+                continue;
+            };
+            let Projection::Perspective(last_perspective) = projection.clone() else {
+                *projection = proj_end.clone();
+                controller.enabled_motion = initial_enabled.clone();
+                *complete = true;
+                continue;
+            };
+
+            let mut delta_translation = DVec3::ZERO;
+
+            let last_fov = last_perspective.fov as f64;
+            let fov_start = perspective_start.fov as f64;
+
+            let fov_end = match &*proj_end {
+                Projection::Perspective(perspective) => perspective.fov as f64,
+                Projection::Orthographic(_) => ZERO_FOV,
+                Projection::Custom(_) => {
+                    error_once!("Custom projections are not supported.");
+                    return;
+                }
+            };
+            let progress = start.elapsed().as_secs_f32() / animation_duration.as_secs_f32();
+            let progress = animation_curve.ease(progress);
+            let next_fov = (1.0 - progress as f64) * fov_start + progress as f64 * fov_end;
+
+            let last_dist = *triangle_base / (last_fov / 2.0).tan();
+            let next_dist = *triangle_base / (next_fov / 2.0).tan();
+            let forward_dist = last_dist - next_dist;
+            let cam_forward = DVec3::NEG_Z;
+            let next_translation = cam_forward * forward_dist;
+
+            delta_translation += next_translation;
+            controller.last_anchor_depth += forward_dist;
+
+            if progress < 1.0 {
+                *projection = Projection::Perspective(PerspectiveProjection {
+                    fov: next_fov as f32,
+                    ..last_perspective
+                });
+            } else {
+                *projection = proj_end.clone();
+                if let Projection::Orthographic(ortho) = &mut *projection {
+                    let multiplier = ortho_tri_base_to_scale_factor(camera, ortho);
+                    ortho.scale = (*triangle_base * multiplier) as f32;
+                }
+                controller.enabled_motion = initial_enabled.clone();
+                *complete = true;
+            }
+            redraw.write(RequestRedraw);
+
+            let mut camera_muts = camera_set.p1();
+            let mut camera_mut = camera_muts.get_mut(*camera_entity).unwrap();
+            apply_delta(&mut camera_mut, delta_translation, DQuat::IDENTITY);
+        }
+        state.map.retain(|_, v| !v.complete);
+    }
+}
+
+fn ortho_tri_base_to_scale_factor(camera: &Camera, ortho: &OrthographicProjection) -> f64 {
+    if let Some(size) = camera.logical_viewport_size() {
+        let (width, height) = (size.x as f64, size.y as f64);
+        2.0 / match ortho.scaling_mode {
+            ScalingMode::WindowSize => height,
+            ScalingMode::AutoMin {
+                min_width,
+                min_height,
+            } => {
+                if width * min_height as f64 > min_width as f64 * height {
+                    min_height as f64
+                } else {
+                    height * min_width as f64 / width
+                }
+            }
+            ScalingMode::AutoMax {
+                max_width,
+                max_height,
+            } => {
+                if (width * max_height as f64) < max_width as f64 * height {
+                    max_height as f64
+                } else {
+                    height * max_width as f64 / width
+                }
+            }
+            ScalingMode::FixedVertical { viewport_height } => viewport_height as f64,
+            ScalingMode::FixedHorizontal { viewport_width } => {
+                height * viewport_width as f64 / width
+            }
+            ScalingMode::Fixed { height, .. } => height as f64,
+        }
+    } else {
+        0.00278
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/independent_skybox.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/independent_skybox.rs
@@ -1,0 +1,226 @@
+//! A `pan_orbit_camera` extension that provides a skybox rendered by a different camera with a
+//! different field of view than the camera it is added to. This allows you to use very narrow
+//! camera FOV, or even orthographic projections, while keeping the appearance of the skybox
+//! unchanged.
+//!
+//! To use it, add a [`IndependentSkybox`] component to a camera,
+//! and add the [`IndependentSkyboxPlugin`] to your app.
+
+use bevy_app::prelude::*;
+use bevy_asset::Handle;
+use bevy_camera::{prelude::*, visibility::RenderLayers, Hdr};
+use bevy_core_pipeline::Skybox;
+use bevy_ecs::prelude::*;
+use bevy_image::Image;
+use bevy_math::Quat;
+use bevy_render::view::Msaa;
+use bevy_transform::prelude::*;
+
+/// See the [module](self) docs.
+pub struct IndependentSkyboxPlugin;
+
+impl Plugin for IndependentSkyboxPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            (
+                IndependentSkyboxCamera::spawn,
+                IndependentSkyboxCamera::despawn,
+                ApplyDeferred,
+                IndependentSkyboxCamera::update,
+            )
+                .chain(),
+        );
+    }
+}
+
+/// When working with orthographic or very narrow field of view cameras, the skybox can appear
+/// distorted. This component allows you to add a skybox to a camera that is rendered by
+/// a separate camera with its own field of view.
+///
+/// There are two camera entities involved when using this setup:
+///
+/// 1. The camera you add the [`IndependentSkybox`] component to. This should be a camera controller, and can use any
+///    projection you like.
+/// 2. A separate camera that is created automatically to render the skybox. This camera will
+///    copy the position and orientation of the first camera, but will use its own field of
+///    view, as specified by the [`IndependentSkybox::fov`] setting. This camera will have the
+///    [`IndependentSkyboxCamera`] component.
+///
+/// This struct controls the parameters used to render the skybox.
+/// [`IndependentSkyboxPlugin`] adds systems to manage the lifecycle of the skybox camera
+/// automatically. You just need to add this component to a camera, and a separate linked skybox camera
+/// will be created, updated, and destroyed as needed.
+#[derive(Debug, Clone, Component)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct IndependentSkybox {
+    /// The image to render as a skybox.
+    pub skybox: Handle<Image>,
+    /// Used to set [`Skybox::brightness`].
+    pub brightness: f32,
+    /// Used to set [`Skybox::rotation`].
+    pub rotation: Quat,
+    /// The [`Camera::order`] of the skybox camera, offset from the camera it is tracking. This
+    /// should be lower than the order of the primary camera controller camera. the default value
+    /// should be sufficient for most cases. You can override this if you have a more complex use
+    /// case with multiple cameras.
+    pub skybox_cam_order_offset: isize,
+    /// The field of view of the skybox.
+    pub fov: SkyboxFov,
+    /// The corresponding skybox camera entity.
+    skybox_cam: Option<Entity>,
+}
+
+impl IndependentSkybox {
+    /// Create a new [`IndependentSkybox`] with default settings and the provided skybox image.
+    pub fn new(skybox: Handle<Image>, brightness: f32, rotation: Quat) -> Self {
+        Self {
+            skybox,
+            brightness,
+            rotation,
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for IndependentSkybox {
+    fn default() -> Self {
+        Self {
+            skybox: Default::default(),
+            brightness: 500.0,
+            rotation: Quat::IDENTITY,
+            skybox_cam_order_offset: -1_000,
+            fov: Default::default(),
+            skybox_cam: Default::default(),
+        }
+    }
+}
+
+/// Field of view setting for the [`IndependentSkybox`]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum SkyboxFov {
+    /// Match the [`PerspectiveProjection::fov`] of the camera this skybox camera is following.
+    Auto,
+    /// Use a fixed value for the skybox field of view. This value is equivalent to
+    /// [`PerspectiveProjection::fov`].
+    Fixed(f32),
+}
+
+impl Default for SkyboxFov {
+    fn default() -> Self {
+        Self::Fixed(PerspectiveProjection::default().fov)
+    }
+}
+
+/// Used to track the camera that is used to render a skybox, using the [`IndependentSkybox`]
+/// component settings placed on a camera.
+#[derive(Component)]
+pub struct IndependentSkyboxCamera {
+    /// The camera that this skybox camera is observing.
+    driven_by: Entity,
+}
+
+impl IndependentSkyboxCamera {
+    /// Spawns [`IndependentSkyboxCamera`]s when a [`IndependentSkybox`] exists without a skybox
+    /// entity.
+    pub fn spawn(
+        mut commands: Commands,
+        mut editor_cams: Query<(Entity, &mut IndependentSkybox, &mut Camera, &Msaa)>,
+        skybox_cams: Query<&IndependentSkyboxCamera>,
+    ) {
+        for (editor_cam_entity, mut editor_without_skybox, mut camera, msaa) in
+            editor_cams.iter_mut().filter(|(_, config, ..)| {
+                config
+                    .skybox_cam
+                    .and_then(|e| skybox_cams.get(e).ok())
+                    .is_none()
+            })
+        {
+            camera.clear_color = ClearColorConfig::None;
+            commands.entity(editor_cam_entity).insert(Hdr);
+
+            let entity = commands
+                .spawn((
+                    Camera3d::default(),
+                    Hdr,
+                    Camera {
+                        order: camera.order + editor_without_skybox.skybox_cam_order_offset,
+                        clear_color: ClearColorConfig::None,
+                        ..Default::default()
+                    },
+                    Projection::Perspective(PerspectiveProjection {
+                        fov: match editor_without_skybox.fov {
+                            SkyboxFov::Auto => PerspectiveProjection::default().fov,
+                            SkyboxFov::Fixed(fov) => fov,
+                        },
+                        ..Default::default()
+                    }),
+                    RenderLayers::none(),
+                    Skybox {
+                        image: Some(editor_without_skybox.skybox.clone()),
+                        brightness: editor_without_skybox.brightness,
+                        rotation: editor_without_skybox.rotation,
+                    },
+                    IndependentSkyboxCamera {
+                        driven_by: editor_cam_entity,
+                    },
+                    *msaa,
+                ))
+                .id();
+            editor_without_skybox.skybox_cam = Some(entity);
+        }
+    }
+
+    /// Despawns [`IndependentSkyboxCamera`]s when their corresponding [`IndependentSkybox`] entity
+    /// does not exist.
+    pub fn despawn(
+        mut commands: Commands,
+        skybox_cams: Query<(Entity, &IndependentSkyboxCamera)>,
+        editor_cams: Query<&IndependentSkybox>,
+    ) {
+        for (skybox_entity, skybox) in &skybox_cams {
+            if editor_cams.get(skybox.driven_by).is_err() {
+                commands.entity(skybox_entity).despawn();
+            }
+        }
+    }
+
+    /// Update the position and projection of this [`IndependentSkyboxCamera`] to copy the camera it
+    /// is following.
+    pub fn update(
+        mut editor_cams: Query<
+            (&IndependentSkybox, &Transform, &Projection, &Camera),
+            (
+                Or<(Changed<IndependentSkybox>, Changed<Transform>)>,
+                Without<Self>,
+            ),
+        >,
+        mut skybox_cams: Query<(Mut<Transform>, Mut<Projection>, Mut<Camera>), With<Self>>,
+    ) {
+        for (editor_cam, editor_transform, editor_projection, camera) in &mut editor_cams {
+            let Some(skybox_entity) = editor_cam.skybox_cam else {
+                continue;
+            };
+            let Ok((mut skybox_transform, mut skybox_projection, mut skybox_camera)) =
+                skybox_cams.get_mut(skybox_entity)
+            else {
+                continue;
+            };
+
+            skybox_camera.viewport.clone_from(&camera.viewport);
+
+            if let Projection::Perspective(editor_perspective) = editor_projection {
+                *skybox_projection = Projection::Perspective(PerspectiveProjection {
+                    fov: match editor_cam.fov {
+                        SkyboxFov::Auto => editor_perspective.fov,
+                        SkyboxFov::Fixed(fov) => fov,
+                    },
+                    ..editor_perspective.clone()
+                });
+            }
+
+            *skybox_transform = *editor_transform;
+        }
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/look_to.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/look_to.rs
@@ -1,0 +1,259 @@
+//! A `pan_orbit_camera` extension that adds the ability to smoothly rotate the camera about its
+//! anchor point until it is looking in the specified direction.
+
+use std::{f64::consts::PI, time::Duration};
+
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_ecs::resource::IsResource;
+use bevy_math::{prelude::*, DAffine3, DQuat, DVec3};
+use bevy_platform::{collections::HashMap, time::Instant};
+use bevy_transform::components::Transform;
+use bevy_window::RequestRedraw;
+
+use crate::pan_orbit_camera::prelude::*;
+
+/// See the [module](self) docs.
+pub struct LookToPlugin;
+
+impl Plugin for LookToPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<LookTo>()
+            .add_message::<LookToTrigger>()
+            .add_systems(
+                PreUpdate,
+                LookTo::update.before(PanOrbitCamera::update_camera_positions),
+            )
+            .add_systems(PostUpdate, LookToTrigger::receive); // In PostUpdate so we don't miss users sending this in Update. LookTo::update will catch the changes next frame.
+    }
+}
+
+/// Send this event to rotate the camera about its anchor until it is looking in the given direction
+/// with the given up direction. Animation speed is configured with the [`LookTo`] resource.
+#[derive(Debug, Message)]
+pub struct LookToTrigger {
+    /// The new direction to face.
+    pub target_facing_direction: DVec3,
+    /// The camera's "up" direction when finished moving.
+    pub target_up_direction: DVec3,
+    /// The camera to update.
+    pub camera: Entity,
+}
+
+impl LookToTrigger {
+    /// Constructs a [`LookToTrigger`] with the up direction automatically selected.
+    ///
+    /// If the camera is set to [`OrbitConstraint::Fixed`], the fixed up direction will be used, as
+    /// long as it is not parallel to the facing direction. If set to [`OrbitConstraint::Free`] or
+    /// the facing direction is parallel to the fixed up direction, the up direction will be
+    /// automatically selected by choosing the axis that results in the least amount of rotation.
+    pub fn auto_snap_up_direction(
+        facing: DVec3,
+        cam_entity: Entity,
+        cam_rotation: &DQuat,
+        cam_editor: &PanOrbitCamera,
+    ) -> Self {
+        const EPSILON: f64 = 0.01;
+        let constraint = match cam_editor.orbit_constraint {
+            OrbitConstraint::Fixed { up, .. } => Some(up),
+            OrbitConstraint::Free => None,
+        }
+        .filter(|up| {
+            let angle = facing.angle_between(*up).abs();
+            angle > EPSILON && angle < PI - EPSILON
+        });
+
+        let up = constraint.unwrap_or_else(|| {
+            let current = cam_rotation;
+            let options = [
+                DVec3::X,
+                DVec3::NEG_X,
+                DVec3::Y,
+                DVec3::NEG_Y,
+                DVec3::Z,
+                DVec3::NEG_Z,
+            ];
+            *options
+                .iter()
+                .map(|d| (d, look_to(facing, *d)))
+                .map(|(d, rot)| (d, rot.angle_between(*current).abs()))
+                .reduce(|acc, this| if this.1 < acc.1 { this } else { acc })
+                .map(|nearest| nearest.0)
+                .unwrap_or(&DVec3::Y)
+        });
+
+        LookToTrigger {
+            target_facing_direction: facing,
+            target_up_direction: up.normalize(),
+            camera: cam_entity,
+        }
+    }
+}
+
+impl LookToTrigger {
+    fn receive(
+        mut events: MessageReader<Self>,
+        mut state: ResMut<LookTo>,
+        mut camera_set: ParamSet<(
+            Query<&mut PanOrbitCamera, Without<IsResource>>,
+            Query<&Transform, (With<PanOrbitCamera>, Without<IsResource>)>,
+        )>,
+        mut redraw: MessageWriter<RequestRedraw>,
+    ) {
+        for event in events.read() {
+            let camera_refs = camera_set.p1();
+            let Ok(cam_transform) = camera_refs.get(event.camera) else {
+                continue;
+            };
+            let Some((_, camera_rotation)) = read_transform(cam_transform) else {
+                continue;
+            };
+            let mut cameras = camera_set.p0();
+            let Ok(mut controller) = cameras.get_mut(event.camera) else {
+                continue;
+            };
+            redraw.write(RequestRedraw);
+            let camera_forward = camera_rotation * DVec3::NEG_Z;
+            let camera_up = camera_rotation * DVec3::Y;
+            state
+                .map
+                .entry(event.camera)
+                .and_modify(|e| {
+                    e.start = Instant::now();
+                    e.initial_facing_direction = camera_forward;
+                    e.initial_up_direction = camera_up;
+                    e.target_facing_direction = event.target_facing_direction;
+                    e.target_up_direction = event.target_up_direction;
+                    e.complete = false;
+                })
+                .or_insert(LookToEntry {
+                    start: Instant::now(),
+                    initial_facing_direction: camera_forward,
+                    initial_up_direction: camera_up,
+                    target_facing_direction: event.target_facing_direction,
+                    target_up_direction: event.target_up_direction,
+                    complete: false,
+                });
+
+            controller.end_move();
+            controller.current_motion = motion::CurrentMotion::Stationary;
+        }
+    }
+}
+
+struct LookToEntry {
+    start: Instant,
+    initial_facing_direction: DVec3,
+    initial_up_direction: DVec3,
+    target_facing_direction: DVec3,
+    target_up_direction: DVec3,
+    complete: bool,
+}
+
+/// Stores settings and state for the dolly zoom plugin.
+#[derive(Resource)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct LookTo {
+    /// The duration of the "look to" transition animation.
+    pub animation_duration: Duration,
+    /// The cubic curve used to animate the camera during a "look to".
+    #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
+    pub animation_curve: CubicSegment<Vec2>,
+    #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
+    map: HashMap<Entity, LookToEntry>,
+}
+
+impl Default for LookTo {
+    fn default() -> Self {
+        Self {
+            animation_duration: Duration::from_millis(400),
+            animation_curve: CubicSegment::new_bezier_easing((0.25, 0.0), (0.25, 1.0)),
+            map: Default::default(),
+        }
+    }
+}
+
+impl LookTo {
+    fn update(
+        mut state: ResMut<Self>,
+        mut camera_set: ParamSet<(
+            Query<&mut PanOrbitCamera>,
+            Query<&Transform, With<PanOrbitCamera>>,
+            Query<&mut Transform, With<PanOrbitCamera>>,
+        )>,
+        mut redraw: MessageWriter<RequestRedraw>,
+    ) {
+        let animation_duration = state.animation_duration;
+        let animation_curve = state.animation_curve;
+        for (
+            camera,
+            LookToEntry {
+                start,
+                initial_facing_direction,
+                initial_up_direction,
+                target_facing_direction,
+                target_up_direction,
+                complete,
+            },
+        ) in state.map.iter_mut()
+        {
+            let camera_refs = camera_set.p1();
+            let Ok(cam_transform) = camera_refs.get(*camera) else {
+                continue;
+            };
+            let Some((mut camera_translation, mut camera_rotation)) = read_transform(cam_transform)
+            else {
+                continue;
+            };
+            let mut cameras = camera_set.p0();
+            let Ok(controller) = cameras.get_mut(*camera) else {
+                *complete = true;
+                continue;
+            };
+            let progress_t =
+                (start.elapsed().as_secs_f32() / animation_duration.as_secs_f32()).clamp(0.0, 1.0);
+            let progress = animation_curve.ease(progress_t);
+
+            let anchor_view_space = controller.anchor_view_space().unwrap_or(DVec3::new(
+                0.0,
+                0.0,
+                controller.last_anchor_depth(),
+            ));
+
+            let anchor_world = {
+                let (r, t) = (camera_rotation, camera_translation);
+                r * anchor_view_space + t
+            };
+
+            let rot_init = look_to(*initial_facing_direction, *initial_up_direction);
+            let rot_target = look_to(*target_facing_direction, *target_up_direction);
+
+            let rot_next = rot_init.slerp(rot_target, progress as f64);
+            let rot_last = camera_rotation;
+            let rot_delta = rot_next * rot_last.inverse();
+
+            let original_translation = camera_translation;
+            let original_rotation = camera_rotation;
+            rotate_around(
+                (&mut camera_translation, &mut camera_rotation),
+                anchor_world,
+                rot_delta,
+            );
+            let (_, delta_rotation, delta_translation) = {
+                let original =
+                    DAffine3::from_rotation_translation(original_rotation, original_translation);
+                let new = DAffine3::from_rotation_translation(camera_rotation, camera_translation);
+                (original.inverse() * new).to_scale_rotation_translation()
+            };
+
+            let mut camera_muts = camera_set.p2();
+            let mut camera_mut = camera_muts.get_mut(*camera).unwrap();
+            apply_delta(&mut camera_mut, delta_translation, delta_rotation);
+            if progress_t >= 1.0 {
+                *complete = true;
+            }
+            redraw.write(RequestRedraw);
+        }
+        state.map.retain(|_, v| !v.complete);
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/mod.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/mod.rs
@@ -1,0 +1,9 @@
+//! Extensions to the base camera controller.
+
+pub mod dolly_zoom;
+pub mod look_to;
+
+#[cfg(feature = "extension_anchor_indicator")]
+pub mod anchor_indicator;
+#[cfg(feature = "extension_independent_skybox")]
+pub mod independent_skybox;

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/input.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/input.rs
@@ -1,0 +1,360 @@
+//! Provides a default input plugin for the camera. See [`DefaultInputPlugin`].
+
+use bevy_app::prelude::*;
+use bevy_camera::{prelude::*, RenderTarget};
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::prelude::*;
+use bevy_input::{
+    mouse::{MouseScrollUnit, MouseWheel},
+    prelude::*,
+};
+use bevy_math::{prelude::*, DVec2, DVec3};
+use bevy_platform::collections::HashMap;
+use bevy_transform::prelude::*;
+use bevy_window::{PrimaryWindow, Window};
+
+use bevy_picking::pointer::{
+    PointerAction, PointerId, PointerInput, PointerInteraction, PointerLocation, PointerMap,
+};
+
+use crate::pan_orbit_camera::prelude::{component::PanOrbitCamera, inputs::MotionInputs};
+
+/// The type of mutually exclusive camera motion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum MotionKind {
+    /// The camera is orbiting and zooming.
+    OrbitZoom,
+    /// The camera is panning and zooming.
+    PanZoom,
+    /// The camera is only zooming.
+    Zoom,
+}
+
+impl From<&MotionInputs> for MotionKind {
+    fn from(value: &MotionInputs) -> Self {
+        match value {
+            MotionInputs::OrbitZoom { .. } => MotionKind::OrbitZoom,
+            MotionInputs::PanZoom { .. } => MotionKind::PanZoom,
+            MotionInputs::Zoom { .. } => MotionKind::Zoom,
+        }
+    }
+}
+
+/// A plugin that provides a default input mapping. Intended to be replaced by users with their own
+/// version of this code, if needed.
+///
+/// The input plugin is responsible for starting motions, sending inputs, and ending motions. See
+/// [`PanOrbitCamera`] for more details on how to implement this yourself.
+pub struct DefaultInputPlugin;
+impl Plugin for DefaultInputPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<PanOrbitCameraInputMessage>()
+            .init_resource::<CameraPointerMap>()
+            .add_systems(
+                PreUpdate,
+                (
+                    default_camera_inputs,
+                    PanOrbitCameraInputMessage::receive_messages,
+                    PanOrbitCameraInputMessage::send_pointer_inputs,
+                )
+                    .chain()
+                    .after(bevy_picking::PickingSystems::Last)
+                    .before(PanOrbitCamera::update_camera_positions),
+            );
+    }
+}
+
+/// A default implementation of an input system
+pub fn default_camera_inputs(
+    pointers: Query<(&PointerId, &PointerLocation)>,
+    pointer_map: Res<CameraPointerMap>,
+    mut controller: MessageWriter<PanOrbitCameraInputMessage>,
+    mut mouse_wheel: MessageReader<MouseWheel>,
+    mouse_input: Res<ButtonInput<MouseButton>>,
+    cameras: Query<(Entity, &Camera, &RenderTarget, &PanOrbitCamera)>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+) {
+    let orbit_start = MouseButton::Right;
+    let pan_start = MouseButton::Left;
+    let zoom_stop = 0.0;
+
+    if let Some(&camera) = pointer_map.get(&PointerId::Mouse) {
+        let camera_query = cameras.get(camera).ok();
+        let is_in_zoom_mode = camera_query
+            .map(|(.., editor_cam)| editor_cam.current_motion.is_zooming_only())
+            .unwrap_or_default();
+        let zoom_amount_abs = camera_query
+            .and_then(|(.., editor_cam)| {
+                editor_cam
+                    .current_motion
+                    .inputs()
+                    .map(|inputs| inputs.zoom_velocity_abs(editor_cam.smoothing.zoom.mul_f32(2.0)))
+            })
+            .unwrap_or(0.0);
+        let should_zoom_end = is_in_zoom_mode && zoom_amount_abs <= zoom_stop;
+
+        if mouse_input.any_just_released([orbit_start, pan_start]) || should_zoom_end {
+            controller.write(PanOrbitCameraInputMessage::End { camera });
+        }
+    }
+
+    for (&pointer, pointer_location) in pointers
+        .iter()
+        .filter_map(|(id, loc)| loc.location().map(|loc| (id, loc)))
+    {
+        match pointer {
+            PointerId::Mouse => {
+                let Some((camera, ..)) = cameras.iter().find(|(_, camera, render_target, _)| {
+                    pointer_location.is_in_viewport(camera, render_target, &primary_window)
+                }) else {
+                    continue; // Pointer must be in viewport to start a motion.
+                };
+
+                if mouse_input.just_pressed(orbit_start) {
+                    controller.write(PanOrbitCameraInputMessage::Start {
+                        kind: MotionKind::OrbitZoom,
+                        camera,
+                        pointer,
+                    });
+                } else if mouse_input.just_pressed(pan_start) {
+                    controller.write(PanOrbitCameraInputMessage::Start {
+                        kind: MotionKind::PanZoom,
+                        camera,
+                        pointer,
+                    });
+                } else if mouse_wheel.read().map(|mw| mw.y.abs()).sum::<f32>() > 0.0 {
+                    // Note we can't just check if the mouse wheel inputs are empty, we need to
+                    // check if the y value abs greater than zero, otherwise we get a bunch of false
+                    // positives, which can cause issues with figuring out what the user is trying
+                    // to do.
+                    controller.write(PanOrbitCameraInputMessage::Start {
+                        kind: MotionKind::Zoom,
+                        camera,
+                        pointer,
+                    });
+                }
+            }
+            PointerId::Touch(_) | PointerId::Custom(_) => continue,
+        }
+    }
+
+    // This must be cleared manually because reading these inputs is conditional - we are not
+    // guaranteed to be flushing the events every frame.
+    mouse_wheel.clear();
+}
+
+/// Maps pointers to the camera they are currently controlling.
+///
+/// This is needed so we can automatically track pointer movements and update camera movement after
+/// a [`PanOrbitCameraInputMessage::Start`] has been received.
+#[derive(Debug, Clone, Default, Deref, DerefMut, Resource)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct CameraPointerMap(HashMap<PointerId, Entity>);
+
+/// Messages used when implementing input systems for the [`PanOrbitCamera`].
+#[derive(Debug, Clone, Message)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum PanOrbitCameraInputMessage {
+    /// Send this event to start moving the camera. The anchor and inputs will be computed
+    /// automatically until the [`PanOrbitCameraInputMessage::End`] event is received.
+    Start {
+        /// The kind of camera movement that is being started.
+        kind: MotionKind,
+        /// The camera to move.
+        camera: Entity,
+        /// The pointer that will be controlling the camera. The rotation anchor point in the world
+        /// will be automatically computed using picking backends.
+        pointer: PointerId,
+    },
+    /// Send this event when a user's input ends, e.g. the button is released.
+    End {
+        /// The entity of the camera that should end its current input motion.
+        camera: Entity,
+    },
+}
+
+impl PanOrbitCameraInputMessage {
+    /// Get the camera entity associated with this event.
+    pub fn camera(&self) -> Entity {
+        match self {
+            PanOrbitCameraInputMessage::Start { camera, .. }
+            | PanOrbitCameraInputMessage::End { camera } => *camera,
+        }
+    }
+
+    /// Receive [`PanOrbitCameraInputMessage`]s, and use these to start and end moves on the [`PanOrbitCamera`].
+    pub fn receive_messages(
+        mut events: MessageReader<Self>,
+        mut controllers: Query<(&mut PanOrbitCamera, &GlobalTransform)>,
+        mut camera_map: ResMut<CameraPointerMap>,
+        pointer_map: Res<PointerMap>,
+        pointer_interactions: Query<&PointerInteraction>,
+        pointer_locations: Query<&PointerLocation>,
+        cameras: Query<(&Camera, &Projection)>,
+        windows: Query<&Window>,
+    ) {
+        for event in events.read() {
+            let Ok((mut controller, cam_transform)) = controllers.get_mut(event.camera()) else {
+                continue;
+            };
+
+            match event {
+                PanOrbitCameraInputMessage::Start { kind, pointer, .. } => {
+                    if controller.is_actively_controlled() {
+                        continue;
+                    }
+                    let anchor = pointer_map
+                        .get_entity(*pointer)
+                        .and_then(|entity| pointer_interactions.get(entity).ok())
+                        .and_then(|interaction| interaction.get_nearest_hit())
+                        // Since `bevy` 0.17.3:
+                        //
+                        // If the current hit is on a window, we cannot use the `hit.position` as an anchor
+                        // as the `hit.position` is in viewport coordinates.
+                        .filter(|(entity, _hit)| !windows.contains(*entity))
+                        .and_then(|(_, hit)| hit.position)
+                        .map(|world_space_hit| {
+                            // Convert the world space hit to view (camera) space
+                            cam_transform
+                                .to_matrix()
+                                .as_dmat4()
+                                .inverse()
+                                .transform_point3(world_space_hit.into())
+                        })
+                        .filter(|p| {
+                            #[cfg(debug_assertions)]
+                            if !p.is_finite() {
+                                bevy_log::warn!("Non-finite input fed to camera controller: {p:?}");
+                            }
+                            p.is_finite()
+                        })
+                        .or_else(|| {
+                            let camera = cameras.get(event.camera()).ok();
+                            let pointer_location = pointer_map
+                                .get_entity(*pointer)
+                                .and_then(|entity| pointer_locations.get(entity).ok())
+                                .and_then(|l| l.location());
+                            if let Some(((camera, proj), pointer_location)) =
+                                camera.zip(pointer_location)
+                            {
+                                screen_to_view_space(
+                                    camera,
+                                    proj,
+                                    &controller,
+                                    pointer_location.position,
+                                )
+                            } else {
+                                None
+                            }
+                        })
+                        .filter(|p| p.is_finite());
+
+                    match kind {
+                        MotionKind::OrbitZoom => controller.start_orbit(anchor),
+                        MotionKind::PanZoom => controller.start_pan(anchor),
+                        MotionKind::Zoom => controller.start_zoom(anchor),
+                    }
+                    camera_map.insert(*pointer, event.camera());
+                }
+                PanOrbitCameraInputMessage::End { .. } => {
+                    controller.end_move();
+                    if let Some(pointer) = camera_map
+                        .iter()
+                        .find(|(.., camera)| **camera == event.camera())
+                        .map(|(&pointer, ..)| pointer)
+                    {
+                        camera_map.remove(&pointer);
+                    }
+                }
+            }
+        }
+    }
+
+    /// While a camera motion is active, this system will take care of sending new pointer motion to
+    /// the camera controller. The camera controller assumes that pan and orbit movements are tied
+    /// to screen space pointer motion.
+    ///
+    /// This is because some of the pixel-perfect features of the controller require that data be
+    /// passed in as screen space deltas, to compute perfect first-order control. This is also
+    /// because the plugin uses pointer information to know which camera is being controlled.
+    ///
+    /// If you want to control the camera with different inputs, you will need to replace this
+    /// system with one that tracks other input methods, and sends the required zoom and screenspace
+    /// movement information.
+    pub fn send_pointer_inputs(
+        camera_map: Res<CameraPointerMap>,
+        mut camera_controllers: Query<&mut PanOrbitCamera>,
+        mut mouse_wheel: MessageReader<MouseWheel>,
+        mut moves: MessageReader<PointerInput>,
+    ) {
+        let moves_list: Vec<_> = moves.read().collect();
+        for (pointer, camera) in camera_map.iter() {
+            let Ok(mut camera_controller) = camera_controllers.get_mut(*camera) else {
+                continue;
+            };
+
+            let screenspace_input = moves_list
+                .iter()
+                .filter(|m| m.pointer_id.eq(pointer))
+                .filter_map(|m| match m.action {
+                    PointerAction::Move { delta } => Some(delta),
+                    _ => None,
+                })
+                .sum();
+
+            let zoom_amount = match pointer {
+                // TODO: add pinch zoom support
+                PointerId::Mouse => mouse_wheel
+                    .read()
+                    .map(|mw| {
+                        let scroll_multiplier = match mw.unit {
+                            MouseScrollUnit::Line => 150.0,
+                            MouseScrollUnit::Pixel => 1.0,
+                        };
+                        mw.y * scroll_multiplier
+                    })
+                    .sum::<f32>(),
+                _ => 0.0,
+            };
+
+            camera_controller.send_screenspace_input(screenspace_input);
+            camera_controller.send_zoom_input(zoom_amount);
+        }
+        // This must be cleared manually because reading these inputs is conditional - we are not
+        // guaranteed to be flushing the events every frame.
+        mouse_wheel.clear();
+    }
+}
+
+fn screen_to_view_space(
+    camera: &Camera,
+    proj: &Projection,
+    controller: &PanOrbitCamera,
+    target_position: Vec2,
+) -> Option<DVec3> {
+    let mut viewport_position = if let Some(rect) = camera.logical_viewport_rect() {
+        target_position.as_dvec2() - rect.min.as_dvec2()
+    } else {
+        target_position.as_dvec2()
+    };
+    let target_size = camera.logical_viewport_size()?.as_dvec2();
+    // Flip the Y co-ordinate origin from the top to the bottom.
+    viewport_position.y = target_size.y - viewport_position.y;
+    let ndc = viewport_position * 2. / target_size - DVec2::ONE;
+    let ndc_to_view = proj.get_clip_from_view().as_dmat4().inverse();
+    let view_near_plane = ndc_to_view.project_point3(ndc.extend(1.));
+    match &proj {
+        Projection::Perspective(_) | Projection::Custom(_) => {
+            // Using EPSILON because an NDC with Z = 0 returns NaNs.
+            let view_far_plane = ndc_to_view.project_point3(ndc.extend(f64::EPSILON));
+            let direction = (view_far_plane - view_near_plane).normalize();
+            Some((direction / direction.z) * controller.last_anchor_depth())
+        }
+        Projection::Orthographic(_) => Some(DVec3::new(
+            view_near_plane.x,
+            view_near_plane.y,
+            controller.last_anchor_depth(),
+        )),
+    }
+}

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/mod.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/mod.rs
@@ -1,0 +1,223 @@
+//! Upstream of awesome [crate](https://github.com/aevyrie/bevy_editor_cam) made by @aevyrie.
+//!
+//! A production-ready camera controller for 3D editors; intended for anyone who needs to rapidly
+//! and intuitively navigate virtual spaces.
+//!
+//! Camera controllers are very subjective! As someone who has spent years using camera controllers
+//! in mechanical engineering CAD software, I've developed my own opinions about what matters in a
+//! camera controller. This is my attempt to make the controller I've always wanted, that fixes the
+//! annoyances I've encountered.
+//!
+//! *Because* camera controllers are so subjective, I felt the need to write out the impetus for
+//! making this thing, what matters to me, and how I decided between conflicting goals. Somehow,
+//! this ended up as a manifesto of sorts. If you came here to learn how to use or extend this
+//! plugin, I've boiled the manifesto down into two sentences:
+//!
+//! > A camera controller needs to be responsive, robust, and satisfying to use. When there is
+//! > conflict between these needs, they should be prioritized in that order.
+//!
+//! Now that you've absorbed my wisdom, feel free to skip ahead to the [Usage](crate#usage) section.
+//!
+//! Or don't. It's up to you.
+//!
+//! # Philosophy
+//!
+//! These are the properties of a good editor camera controller, in order of importance. These are
+//! the driving values for the choices I've made here. You might disagree and have different values
+//! or priorities!
+//!
+//! ## Responsive
+//!
+//! A good camera controller should never feel floaty or disconnected. It should go exactly where
+//! the user commands it to go. Responsiveness isn't simply "low latency", it's about respecting the
+//! user's intent.
+//!
+//! #### First-order input
+//!
+//! The most precise inputs are first-order, that is, controlling the position of something
+//! directly, instead of its velocity (second-order) or acceleration (third-order). An example of
+//! this is using a mouse vs. a gamepad for controlling the rotation of a first person view. The
+//! mouse is first order, the position of the mouse on the mousepad directly corresponds with the
+//! direction the player is facing. Conversely, a joystick controls the velocity of the view
+//! rotation. All that is to say, where possible, the camera controller should use pointer inputs
+//! *directly*.
+//!
+//! #### Pixel-perfect panning
+//!
+//! When you click and drag to pan the scene, the thing you click on should stick to your pointer,
+//! and never drift. This should hold true even if inputs are being smoothed.
+//!
+//! #### Intuitive zoom
+//!
+//! The camera should zoom in and out in the direction you are pointing. If the user is hovering
+//! over something, the speed of the camera should automatically adjust to quickly zoom up to it
+//! without clipping through it.
+//!
+//! #### Predictable rotation
+//!
+//! When you click and drag to orbit the scene in 3d, the center of rotation should be located where
+//! your pointer was when the drag started.
+//!
+//! #### Intuitive perspective toggle
+//!
+//! Toggling between different fields of view, or between perspective and orthographic projections,
+//! should not cause the camera view to jump or change suddenly. The view should smoothly warp,
+//! keeping the last interacted point stationary on the screen.
+//!
+//! ## Robust
+//!
+//! A camera controller should work in any scenario, and handle failure gracefully and
+//! unsurprisingly when inputs are ambiguous.
+//!
+//! #### Works in all conditions:
+//!
+//! All of features in the previous section should work regardless of framerate, distance, scale,
+//! camera field of view, and camera projection - including orthographic.
+//!
+//! #### Graceful fallback
+//!
+//! if nothing is under the pointer when a camera motion starts, the last-known depth should be
+//! used, to prevent erratic behavior when the hit test fails. If a user was orbiting around a point
+//! on an object, then clicks to rotate about empty space, the camera should not shoot off into
+//! space because nothing was under the cursor.
+//!
+//! ### Satisfying
+//!
+//! The controller should *feel* good to use.
+//!
+//! #### Momentum
+//!
+//! Panning and orbiting should support configurable momentum, to allow you to "flick" the camera
+//! through the scene to cover distance and make the feel of the camera tunable. This is especially
+//! useful for trackpad and touch users.
+//!
+//! #### Smoothness
+//!
+//! The smoothness of inputs should be configurable as a tradeoff between fluidity of motion and
+//! responsiveness. This is particularly useful when showing the screen to other people, where fast
+//! motions can be disorienting or even nauseating.
+//!
+//! # Usage
+//!
+//! This plugin only requires three things to work. The `bevy_picking` plugin for hit tests, the
+//! [`DefaultPanOrbitCameraPlugins`] plugin group, and the [`PanOrbitCamera`](crate::pan_orbit_camera::prelude::PanOrbitCamera)
+//! component. Controller settings are configured per-camera in the
+//! [`PanOrbitCamera`](crate::pan_orbit_camera::prelude::PanOrbitCamera) component.
+//!
+//! ## Getting Started
+//!
+//! #### 1. Add `bevy_picking`
+//!
+//! The camera controller uses [`bevy_picking`] for pointer interactions. If you already it along
+//! with a picking backend, then using this camera controller is essentially free because it can
+//! reuse those same hit tests you are already running.
+//!
+//! #### 2. Add `DefaultPanOrbitCameraPlugins`
+//!
+//! This is a plugin group that adds the camera controller, as well as all the [extensions]. You can
+//! instead add [`controller::MinimalPanOrbitCameraPlugin`], though you will need to add your own input
+//! plugin if you do.
+//!
+//! ```
+//! # let mut app = bevy_app::App::new();
+//! app.add_plugins(bevy_camera_controller::pan_orbit_camera::DefaultPanOrbitCameraPlugins);
+//! ```
+//!
+//! #### 3. Insert the `PanOrbitCamera` component
+//!
+//! Finally, insert [`controller::component::PanOrbitCamera`] onto any cameras that you want to control.
+//! This marks the cameras as controllable and holds all camera controller settings.
+//!
+//! ```
+//! # use bevy_ecs::system::Commands;
+//! # use bevy_camera_controller::pan_orbit_camera::prelude::*;
+//! # fn test(mut commands: Commands) {
+//! commands.spawn((
+//!     // Camera
+//!     PanOrbitCamera::default(),
+//! ));
+//! # }
+//! ```
+//!
+//! # Other notable features
+//!
+//! Crate contains implementation of few other features that are handy for a camera controller like this.
+//!
+//! ### Compatible with floating origins and other controllers
+//!
+//! This controller does all computations in view space. The result of this is that you can move the
+//! camera wherever you want, update its transform, and it will continue to behave normally, as long
+//! as the camera isn't being controlled by the user while you do this. This means you can control
+//! this camera with another camera controller, or use it in a floating origin system.
+//!
+//! ### Independent skybox
+//!
+//! When working in a CAD context, it is common to use orthographic projections to remove
+//! perspective distortion from the image. However, because an ortho projection has zero field of
+//! view, the view of the skybox is infinitesimally small, i.e. only a single pixel of the skybox is
+//! visible. To fix this, an [extension](extensions) is provided to attach a skybox to a camera that
+//! is independent from that camera's field of view.
+//!
+//! ### Pointer and Hit Test Agnostic
+//!
+//! Users of this library shouldn't be forced into using any particular hit testing method, like CPU
+//! raycasting. The controller uses [`bevy_picking`] to work with:
+//!
+//! - Arbitrary hit testing backends, including those written by users. See
+//!   [`bevy_picking::backend`] for more information.
+//! - Any number of pointing inputs, including touch.
+//! - Viewports and multi-pass rendering.
+
+#![warn(missing_docs)]
+
+pub mod controller;
+pub mod extensions;
+pub mod input;
+
+/// Common imports.
+pub mod prelude {
+    pub use crate::{
+        pan_orbit_camera::controller::{component::*, transform_utils::*, *},
+        pan_orbit_camera::DefaultPanOrbitCameraPlugins,
+    };
+}
+
+use bevy_app::{prelude::*, PluginGroupBuilder};
+use bevy_ecs::prelude::SystemSet;
+
+/// Adds [`pan_orbit_camera`](crate::pan_orbit_camera) functionality with all extensions and the default input plugin.
+///
+/// This is intended for a quick and easy setup. You can add the individual plugins yourself if you
+/// want more control over the setup.
+///
+/// To be more precise, this plugin group adds the following plugins:
+///
+/// - [`controller::MinimalPanOrbitCameraPlugin`]
+/// - [`input::DefaultInputPlugin`]
+/// - [`extensions::dolly_zoom::DollyZoomPlugin`]
+/// - [`extensions::look_to::LookToPlugin`]
+/// - [`extensions::anchor_indicator::AnchorIndicatorPlugin`] (if the `extension_anchor_indicator` feature is enabled)
+/// - [`extensions::independent_skybox::IndependentSkyboxPlugin`] (if the `extension_independent_skybox` feature is enabled)
+pub struct DefaultPanOrbitCameraPlugins;
+
+/// This system set may alter the camera position in the `PreUpdate` schedule.
+#[derive(SystemSet, Default, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SyncCameraPosition;
+
+impl PluginGroup for DefaultPanOrbitCameraPlugins {
+    fn build(self) -> PluginGroupBuilder {
+        let group = PluginGroupBuilder::start::<Self>()
+            .add(input::DefaultInputPlugin)
+            .add(controller::MinimalPanOrbitCameraPlugin)
+            .add(extensions::dolly_zoom::DollyZoomPlugin)
+            .add(extensions::look_to::LookToPlugin);
+
+        #[cfg(feature = "extension_anchor_indicator")]
+        let group = group.add(extensions::anchor_indicator::AnchorIndicatorPlugin);
+
+        #[cfg(feature = "extension_independent_skybox")]
+        let group = group.add(extensions::independent_skybox::IndependentSkyboxPlugin);
+
+        group
+    }
+}

--- a/crates/bevy_color/src/color_ops.rs
+++ b/crates/bevy_color/src/color_ops.rs
@@ -4,12 +4,12 @@ use bevy_math::{ops, Vec3, Vec4};
 /// guaranteed to produce consistent results across color spaces,
 /// but will be within a given space.
 pub trait Luminance: Sized {
-    /// Return the luminance of this color (0.0 - 1.0).
+    /// Return the luminance of this color. SDR colors are in `[0.0, 1.0]`. An HDR
+    /// color's luminance can be above or below 1.0.
     fn luminance(&self) -> f32;
 
-    /// Return a new version of this color with the given luminance. The resulting color will
-    /// be clamped to the valid range for the color space; for some color spaces, clamping
-    /// may cause the hue or chroma to change.
+    /// Return a new version of this color with the given luminance. The result is not
+    /// clamped, so an out-of-range target is stored as-is.
     fn with_luminance(&self, value: f32) -> Self;
 
     /// Return a darker version of this color. The `amount` should be between 0.0 and 1.0.
@@ -23,7 +23,8 @@ pub trait Luminance: Sized {
     /// Return a lighter version of this color. The `amount` should be between 0.0 and 1.0.
     /// The amount represents an absolute increase in luminance, and is distributive:
     /// `color.lighter(a).lighter(b) == color.lighter(a + b)`. Colors are clamped to white
-    /// if the amount would cause them to go above white.
+    /// if the amount would cause them to go above white, so this operation is not suitable
+    /// for HDR colors. To scale an HDR color, use [`with_luminance`](Luminance::with_luminance).
     ///
     /// For a relative increase in luminance, you can simply `mix()` with white.
     fn lighter(&self, amount: f32) -> Self;

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -25,7 +25,7 @@ use bevy_reflect::prelude::*;
 pub struct Lcha {
     /// The lightness channel. [0.0, 1.5]
     pub lightness: f32,
-    /// The chroma channel. [0.0, 1.5]
+    /// The chroma channel. Typically [0.0, 1.5]
     pub chroma: f32,
     /// The hue channel. [0.0, 360.0]
     pub hue: f32,
@@ -41,7 +41,7 @@ impl Lcha {
     /// # Arguments
     ///
     /// * `lightness` - Lightness channel. [0.0, 1.5]
-    /// * `chroma` - Chroma channel. [0.0, 1.5]
+    /// * `chroma` - Chroma channel. Typically [0.0, 1.5]
     /// * `hue` - Hue channel. [0.0, 360.0]
     /// * `alpha` - Alpha channel. [0.0, 1.0]
     pub const fn new(lightness: f32, chroma: f32, hue: f32, alpha: f32) -> Self {
@@ -58,7 +58,7 @@ impl Lcha {
     /// # Arguments
     ///
     /// * `lightness` - Lightness channel. [0.0, 1.5]
-    /// * `chroma` - Chroma channel. [0.0, 1.5]
+    /// * `chroma` - Chroma channel. Typically [0.0, 1.5]
     /// * `hue` - Hue channel. [0.0, 360.0]
     pub const fn lch(lightness: f32, chroma: f32, hue: f32) -> Self {
         Self {
@@ -279,19 +279,9 @@ impl From<Laba> for Lcha {
         }: Laba,
     ) -> Self {
         // Based on http://www.brucelindbloom.com/index.html?Eqn_Lab_to_LCH.html
-        let c = ops::hypot(a, b);
-        let h = {
-            let h = ops::atan2(b.to_radians(), a.to_radians()).to_degrees();
-
-            if h < 0.0 {
-                h + 360.0
-            } else {
-                h
-            }
-        };
-
-        let chroma = c.clamp(0.0, 1.5);
-        let hue = h;
+        let chroma = ops::hypot(a, b);
+        let hue = ops::atan2(b, a).to_degrees();
+        let hue = if hue < 0.0 { hue + 360.0 } else { hue };
 
         Lcha::new(lightness, chroma, hue, alpha)
     }
@@ -368,6 +358,18 @@ mod tests {
             }
             assert_approx_eq!(color.lch.alpha, lcha.alpha, 0.001);
         }
+    }
+
+    #[test]
+    fn wide_gamut_chroma_preserved() {
+        let laba = Laba::new(0.8, 1.5, -1.2, 1.0);
+        let lcha: Lcha = laba.into();
+        assert!(lcha.chroma > 1.9, "chroma was clamped: {:?}", lcha);
+
+        let back: Laba = lcha.into();
+        assert_approx_eq!(laba.lightness, back.lightness, 1e-4);
+        assert_approx_eq!(laba.a, back.a, 1e-4);
+        assert_approx_eq!(laba.b, back.b, 1e-4);
     }
 
     #[test]

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -119,6 +119,7 @@ mod okhwba;
 mod oklaba;
 mod oklcha;
 pub mod palettes;
+mod primaries;
 mod srgba;
 #[cfg(test)]
 mod test_colors;
@@ -152,6 +153,7 @@ pub use okhsva::*;
 pub use okhwba::*;
 pub use oklaba::*;
 pub use oklcha::*;
+pub use primaries::*;
 pub use srgba::*;
 pub use xyza::*;
 

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -8,6 +8,8 @@ use bevy_reflect::prelude::*;
 use bytemuck::{Pod, Zeroable};
 
 /// Linear RGB color with alpha.
+///
+/// SDR colors are in `[0.0, 1.0]`. Values above `1.0` are HDR intensities.
 #[doc = include_str!("../docs/conversion.md")]
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
@@ -25,11 +27,11 @@ use bytemuck::{Pod, Zeroable};
 )]
 #[repr(C)]
 pub struct LinearRgba {
-    /// The red channel. [0.0, 1.0]
+    /// The red channel. [0.0, 1.0] for SDR colors.
     pub red: f32,
-    /// The green channel. [0.0, 1.0]
+    /// The green channel. [0.0, 1.0] for SDR colors.
     pub green: f32,
-    /// The blue channel. [0.0, 1.0]
+    /// The blue channel. [0.0, 1.0] for SDR colors.
     pub blue: f32,
     /// The alpha channel. [0.0, 1.0]
     pub alpha: f32,
@@ -177,18 +179,22 @@ impl Luminance for LinearRgba {
         self.red * 0.2126 + self.green * 0.7152 + self.blue * 0.0722
     }
 
+    /// Scales the color to the target luminance, preserving its chromaticity. A saturated
+    /// color or a target above 1.0 can push components outside `[0.0, 1.0]`.
     #[inline]
     fn with_luminance(&self, luminance: f32) -> Self {
         let current_luminance = self.luminance();
         let adjustment = luminance / current_luminance;
         Self {
-            red: (self.red * adjustment).clamp(0., 1.),
-            green: (self.green * adjustment).clamp(0., 1.),
-            blue: (self.blue * adjustment).clamp(0., 1.),
+            red: self.red * adjustment,
+            green: self.green * adjustment,
+            blue: self.blue * adjustment,
             alpha: self.alpha,
         }
     }
 
+    /// The target luminance is clamped to `[0.0, 1.0]`, so this is not suitable for HDR
+    /// colors. To scale an HDR color, use [`with_luminance`](Luminance::with_luminance).
     #[inline]
     fn darker(&self, amount: f32) -> Self {
         let mut result = *self;
@@ -196,6 +202,8 @@ impl Luminance for LinearRgba {
         result
     }
 
+    /// The target luminance is clamped to `[0.0, 1.0]`, so this is not suitable for HDR
+    /// colors. To scale an HDR color, use [`with_luminance`](Luminance::with_luminance).
     #[inline]
     fn lighter(&self, amount: f32) -> Self {
         let mut result = *self;
@@ -459,6 +467,34 @@ mod tests {
         let a = LinearRgba::rgb(0.0, 100.0, -100.0).to_u8_array_no_alpha();
         let b = [0, 255, 0];
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn with_luminance_scales_unclamped() {
+        use crate::testing::assert_approx_eq;
+
+        // A target above 1.0 produces an HDR color.
+        let gray = LinearRgba::rgb(0.5, 0.5, 0.5);
+        let bright = gray.with_luminance(2.0);
+        assert_approx_eq!(bright.red, 2.0, 1e-4);
+        assert_approx_eq!(bright.green, 2.0, 1e-4);
+        assert_approx_eq!(bright.blue, 2.0, 1e-4);
+
+        // An HDR color scales and keeps its chromaticity.
+        let hdr = LinearRgba::rgb(2.0, 4.0, 8.0);
+        let adjusted = hdr.with_luminance(2.0 * hdr.luminance());
+        assert_approx_eq!(adjusted.red, 4.0, 1e-4);
+        assert_approx_eq!(adjusted.green, 8.0, 1e-4);
+        assert_approx_eq!(adjusted.blue, 16.0, 1e-4);
+
+        // A saturated SDR color scales past 1.0 instead of clamping, and the
+        // result hits the requested luminance exactly.
+        let red = LinearRgba::rgb(1.0, 0.0, 0.0);
+        let bright = red.with_luminance(0.9);
+        assert!(bright.red > 4.0);
+        assert_eq!(bright.green, 0.0);
+        assert_eq!(bright.blue, 0.0);
+        assert_approx_eq!(bright.luminance(), 0.9, 1e-4);
     }
 
     #[test]

--- a/crates/bevy_color/src/okhsla.rs
+++ b/crates/bevy_color/src/okhsla.rs
@@ -10,6 +10,9 @@ use bevy_reflect::prelude::*;
 
 /// Color in Okhsl color space with alpha
 /// Further information on this color model can be found on <https://bottosson.github.io/posts/colorpicker>.
+///
+/// Okhsl is defined relative to the sRGB (Rec. 709) gamut. Converting a wide-gamut or
+/// HDR color clamps the lightness to `1.0` but can push saturation outside `[0.0, 1.0]`.
 #[doc = include_str!("../docs/conversion.md")]
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]

--- a/crates/bevy_color/src/okhsva.rs
+++ b/crates/bevy_color/src/okhsva.rs
@@ -10,6 +10,9 @@ use bevy_reflect::prelude::*;
 
 /// Color in Okhsv color space with alpha.
 /// Further information on this color model can be found on <https://bottosson.github.io/posts/colorpicker>.
+///
+/// Okhsv is defined relative to the sRGB (Rec. 709) gamut. Converting a wide-gamut or
+/// HDR color can push saturation and value outside `[0.0, 1.0]`.
 #[doc = include_str!("../docs/conversion.md")]
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]

--- a/crates/bevy_color/src/primaries.rs
+++ b/crates/bevy_color/src/primaries.rs
@@ -1,0 +1,243 @@
+//! CIE 1931 chromaticity coordinates and RGB primary sets, used to convert linear RGB
+//! values from one color space to another.
+//!
+//! Matrices are derived from chromaticity coordinates with the
+//! [Lindbloom method](http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html).
+
+use crate::Xyza;
+use bevy_math::{DMat3, DVec3, Mat3};
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::prelude::*;
+
+/// A position in the [CIE 1931 xy chromaticity diagram](https://en.wikipedia.org/wiki/CIE_1931_color_space),
+/// describing a color's hue and saturation independently of its luminance.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Clone, PartialEq, Default)
+)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
+pub struct Chromaticity {
+    /// The x chromaticity coordinate. Physical colors are in `[0.0, 0.8]`.
+    pub x: f32,
+    /// The y chromaticity coordinate. Physical colors are in `(0.0, 0.9]`.
+    pub y: f32,
+}
+
+impl Chromaticity {
+    /// Construct a new [`Chromaticity`] from CIE 1931 xy coordinates.
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    /// The [CIE Standard Illuminant D65](https://registry.color.org/rgb-registry/srgb#:~:text=White%20point%20chromaticity)
+    /// white point, as specified by ITU-R BT.709 / BT.2020 and the sRGB standard.
+    pub const D65: Self = Self::new(0.3127, 0.3290);
+
+    /// The [ACES white point](https://docs.acescentral.com/white-point/), about
+    /// CIE Standard Illuminant D60.
+    pub const D60: Self = Self::new(0.32168, 0.33767);
+
+    /// Convert this chromaticity and a luminance to a CIE 1931 color space.
+    ///
+    /// A luminance of `1.0` is the reference white. Alpha is set to `1.0`.
+    pub const fn to_xyza(self, luminance: f32) -> Xyza {
+        let xyz = self.to_dxyz();
+        Xyza::new(
+            (xyz.x * luminance as f64) as f32,
+            luminance,
+            (xyz.z * luminance as f64) as f32,
+            1.0,
+        )
+    }
+
+    /// The CIE 1931 XYZ tristimulus value of this chromaticity at luminance `1.0`,
+    /// in `f64` precision for matrix derivation.
+    const fn to_dxyz(self) -> DVec3 {
+        let (x, y) = (self.x as f64, self.y as f64);
+        DVec3::new(x / y, 1.0, (1.0 - x - y) / y)
+    }
+}
+
+impl Default for Chromaticity {
+    fn default() -> Self {
+        Self::D65
+    }
+}
+
+/// A set of RGB primaries and a white point, given as [`Chromaticity`] coordinates.
+///
+/// Together they define what a linear RGB color looks like, aside from overall brightness.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Clone, PartialEq, Default)
+)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
+pub struct RgbPrimaries {
+    /// The chromaticity of the red primary.
+    pub red: Chromaticity,
+    /// The chromaticity of the green primary.
+    pub green: Chromaticity,
+    /// The chromaticity of the blue primary.
+    pub blue: Chromaticity,
+    /// The chromaticity of the white point (the color produced by `(1, 1, 1)`).
+    pub white: Chromaticity,
+}
+
+impl RgbPrimaries {
+    /// The [ITU-R BT.709](https://registry.color.org/rgb-registry/bt709) primaries with a D65
+    /// white point.
+    ///
+    /// sRGB and [`LinearRgba`](crate::LinearRgba) use these primaries.
+    pub const BT709: Self = Self {
+        red: Chromaticity::new(0.640, 0.330),
+        green: Chromaticity::new(0.300, 0.600),
+        blue: Chromaticity::new(0.150, 0.060),
+        white: Chromaticity::D65,
+    };
+
+    /// The [ITU-R BT.2020](https://registry.color.org/rgb-registry/bt2020) (Rec. 2020)
+    /// wide-gamut primaries with a D65 white point.
+    pub const BT2020: Self = Self {
+        red: Chromaticity::new(0.708, 0.292),
+        green: Chromaticity::new(0.170, 0.797),
+        blue: Chromaticity::new(0.131, 0.046),
+        white: Chromaticity::D65,
+    };
+
+    /// The [Display P3](https://registry.color.org/rgb-registry/displayp3) primaries:
+    /// the DCI-P3 primaries with a D65 white point.
+    pub const DISPLAY_P3: Self = Self {
+        red: Chromaticity::new(0.680, 0.320),
+        green: Chromaticity::new(0.265, 0.690),
+        blue: Chromaticity::new(0.150, 0.060),
+        white: Chromaticity::D65,
+    };
+
+    /// The [ACEScg](https://docs.acescentral.com/encodings/acescg) (AP1) primaries
+    /// with the ACES white point, used for scene-linear rendering.
+    pub const ACES_CG: Self = Self {
+        red: Chromaticity::new(0.713, 0.293),
+        green: Chromaticity::new(0.165, 0.830),
+        blue: Chromaticity::new(0.128, 0.044),
+        white: Chromaticity::D60,
+    };
+
+    /// Returns a matrix that converts linear RGB colors from these primaries to `dst`
+    /// primaries.
+    ///
+    /// White points are not adapted. Converting between sets with different whites, such as
+    /// [`RgbPrimaries::ACES_CG`] and a D65 set, leaves a small shift in white.
+    /// The matrix is computed in `f64` and rounded to `f32`.
+    pub fn matrix_to(self, dst: Self) -> Mat3 {
+        (dst.rgb_to_xyz_dmat3().inverse() * self.rgb_to_xyz_dmat3()).as_mat3()
+    }
+
+    /// Derive the RGB to XYZ matrix in `f64` precision. The matrix maps `(1, 1, 1)`
+    /// to the XYZ value of [`Self::white`] at luminance `1.0`.
+    fn rgb_to_xyz_dmat3(&self) -> DMat3 {
+        let primaries = DMat3::from_cols(
+            self.red.to_dxyz(),
+            self.green.to_dxyz(),
+            self.blue.to_dxyz(),
+        );
+        // Scale each column so that (1, 1, 1) maps to the white point at Y = 1.
+        let scale = primaries.inverse() * self.white.to_dxyz();
+        primaries * DMat3::from_diagonal(scale)
+    }
+}
+
+impl Default for RgbPrimaries {
+    fn default() -> Self {
+        Self::BT709
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::{assert_approx_eq, assert_mat3_approx_eq};
+    use bevy_math::Vec3;
+
+    #[test]
+    fn bt709_to_bt2020_matches_bt2087() {
+        // Published ITU-R BT.2087-0 (table in section 2.2.1) Rec.709 to Rec.2020 matrix.
+        let expected = Mat3::from_cols_array_2d(&[
+            [0.6274, 0.0691, 0.0164],
+            [0.3293, 0.9195, 0.0880],
+            [0.0433, 0.0114, 0.8956],
+        ]);
+        let m = RgbPrimaries::BT709.matrix_to(RgbPrimaries::BT2020);
+        assert_mat3_approx_eq(m, expected, 1e-4);
+    }
+
+    #[test]
+    fn rgb_to_rgb_round_trip_is_identity() {
+        let sets = [
+            RgbPrimaries::BT709,
+            RgbPrimaries::BT2020,
+            RgbPrimaries::DISPLAY_P3,
+            RgbPrimaries::ACES_CG,
+        ];
+        for src in sets {
+            for dst in sets {
+                let round_trip = dst.matrix_to(src) * src.matrix_to(dst);
+                assert_mat3_approx_eq(round_trip, Mat3::IDENTITY, 1e-6);
+            }
+        }
+    }
+
+    #[test]
+    fn white_maps_to_white_point() {
+        for primaries in [
+            RgbPrimaries::BT709,
+            RgbPrimaries::BT2020,
+            RgbPrimaries::DISPLAY_P3,
+            RgbPrimaries::ACES_CG,
+        ] {
+            let white_xyz = primaries.rgb_to_xyz_dmat3().as_mat3() * Vec3::ONE;
+            let expected = primaries.white.to_xyza(1.0);
+            assert_approx_eq!(white_xyz.x, expected.x, 1e-6);
+            assert_approx_eq!(white_xyz.y, expected.y, 1e-6);
+            assert_approx_eq!(white_xyz.z, expected.z, 1e-6);
+        }
+    }
+
+    #[test]
+    fn bt709_matrix_matches_crate_srgb_matrix() {
+        // This crate's sRGB matrices use Lindbloom's D65, XYZ 0.95047, 1.0, 1.08883 from
+        // ASTM E308. White from the BT.709 chromaticity 0.3127, 0.3290 differs by about
+        // 2e-4, so this check is only approximate.
+        let expected = Mat3::from_cols_array_2d(&[
+            [0.4124564, 0.2126729, 0.0193339],
+            [0.3575761, 0.7151522, 0.119192],
+            [0.1804375, 0.072175, 0.9503041],
+        ]);
+        let m = RgbPrimaries::BT709.rgb_to_xyz_dmat3().as_mat3();
+        assert_mat3_approx_eq(m, expected, 5e-4);
+    }
+
+    #[test]
+    fn chromaticity_to_xyza() {
+        let xyz = Chromaticity::D65.to_xyza(1.0);
+        assert_approx_eq!(xyz.x, 0.9504559, 1e-6);
+        assert_approx_eq!(xyz.y, 1.0, 1e-6);
+        assert_approx_eq!(xyz.z, 1.0890578, 1e-6);
+        assert_approx_eq!(xyz.alpha, 1.0, 1e-6);
+
+        let xyz = Chromaticity::D65.to_xyza(2.0);
+        assert_approx_eq!(xyz.y, 2.0, 1e-6);
+        assert_approx_eq!(xyz.x, 2.0 * 0.9504559, 1e-5);
+    }
+}

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -10,6 +10,8 @@ use bevy_reflect::prelude::*;
 use thiserror::Error;
 
 /// Non-linear standard RGB with alpha.
+///
+/// SDR colors are in `[0.0, 1.0]`. Values above `1.0` are HDR intensities.
 #[doc = include_str!("../docs/conversion.md")]
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
@@ -26,11 +28,11 @@ use thiserror::Error;
     reflect(Serialize, Deserialize)
 )]
 pub struct Srgba {
-    /// The red channel. [0.0, 1.0]
+    /// The red channel. [0.0, 1.0] for SDR colors.
     pub red: f32,
-    /// The green channel. [0.0, 1.0]
+    /// The green channel. [0.0, 1.0] for SDR colors.
     pub green: f32,
-    /// The blue channel. [0.0, 1.0]
+    /// The blue channel. [0.0, 1.0] for SDR colors.
     pub blue: f32,
     /// The alpha channel. [0.0, 1.0]
     pub alpha: f32,

--- a/crates/bevy_color/src/testing.rs
+++ b/crates/bevy_color/src/testing.rs
@@ -27,3 +27,17 @@ macro_rules! assert_approx_eq {
 
 #[cfg(test)]
 pub(crate) use assert_approx_eq;
+
+#[cfg(test)]
+pub(crate) fn assert_mat3_approx_eq(a: bevy_math::Mat3, b: bevy_math::Mat3, tolerance: f32) {
+    for col in 0..3 {
+        for row in 0..3 {
+            assert_approx_eq!(
+                a.col(col)[row],
+                b.col(col)[row],
+                tolerance,
+                alloc::format!("matrices differ at column {col}, row {row}: {a} != {b}")
+            );
+        }
+    }
+}

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -7,6 +7,8 @@ use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
 
 /// [CIE 1931](https://en.wikipedia.org/wiki/CIE_1931_color_space) color space, also known as XYZ, with an alpha channel.
+///
+/// The SDR channel bounds below are the D65 white point, `(0.9505, 1.0, 1.0889)`.
 #[doc = include_str!("../docs/conversion.md")]
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
@@ -23,11 +25,11 @@ use bevy_reflect::prelude::*;
     reflect(Serialize, Deserialize)
 )]
 pub struct Xyza {
-    /// The x-axis. [0.0, 1.0]
+    /// The x-axis. [0.0, 0.9505] for SDR colors.
     pub x: f32,
-    /// The y-axis, intended to represent luminance. [0.0, 1.0]
+    /// The y-axis, intended to represent luminance. [0.0, 1.0] for SDR colors.
     pub y: f32,
-    /// The z-axis. [0.0, 1.0]
+    /// The z-axis. [0.0, 1.0889] for SDR colors.
     pub z: f32,
     /// The alpha channel. [0.0, 1.0]
     pub alpha: f32,

--- a/crates/bevy_core_pipeline/src/blit/blit.wesl
+++ b/crates/bevy_core_pipeline/src/blit/blit.wesl
@@ -1,4 +1,4 @@
-import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
+import package::fullscreen_vertex_shader::FullscreenVertexOutput;
 @if(SRGB_TO_LINEAR) import bevy_render::color_operations::srgb_to_linear;
 @if(OKLAB_TO_LINEAR) import bevy_render::color_operations::oklab_to_linear_rgb;
 

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -30,7 +30,7 @@ pub const DEPTH_PREPASS_TEXTURE_SUPPORTED: bool = false;
 #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
 pub const DEPTH_PREPASS_TEXTURE_SUPPORTED: bool = true;
 
-use core::{f32, ops::Range};
+use core::ops::Range;
 
 use bevy_camera::{Camera, Camera3d, Camera3dDepthLoadOp};
 use bevy_diagnostic::FrameCount;

--- a/crates/bevy_core_pipeline/src/deferred/copy_deferred_lighting_id.wesl
+++ b/crates/bevy_core_pipeline/src/deferred/copy_deferred_lighting_id.wesl
@@ -1,4 +1,4 @@
-import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
+import package::fullscreen_vertex_shader::FullscreenVertexOutput;
 
 @group(0) @binding(0)
 var material_id_texture: texture_2d<u32>;

--- a/crates/bevy_core_pipeline/src/fullscreen_material.rs
+++ b/crates/bevy_core_pipeline/src/fullscreen_material.rs
@@ -17,10 +17,11 @@ use bevy_ecs::{
     query::With,
     resource::Resource,
     schedule::{IntoScheduleConfigs, ScheduleConfigs, ScheduleLabel},
-    system::{BoxedSystem, Commands, Query, Res, ResMut},
+    system::{BoxedSystem, Commands, Local, Query, Res, ResMut},
 };
 use bevy_render::{
     camera::ExtractedCamera,
+    diagnostic::RecordDiagnostics,
     extract_component::{
         ComponentUniforms, DynamicUniformIndex, ExtractComponent, ExtractComponentPlugin,
         UniformComponentPlugin,
@@ -295,6 +296,7 @@ pub fn fullscreen_material_system<T: FullscreenMaterial>(
     )>,
     pipeline_cache: Res<PipelineCache>,
     mut ctx: RenderContext,
+    mut pass_label: Local<String>,
 ) {
     let (view_target, settings_index, bind_groups, pipeline_id) = view.into_inner();
 
@@ -308,8 +310,11 @@ pub fn fullscreen_material_system<T: FullscreenMaterial>(
 
     let bind_group = bind_groups.cache.get_current_bind_group(source);
 
+    if pass_label.is_empty() {
+        *pass_label = format!("fullscreen_material_pass<{}>", type_name::<T>());
+    }
     let pass_descriptor = RenderPassDescriptor {
-        label: Some("fullscreen_material_pass"),
+        label: Some(&pass_label),
         color_attachments: &[Some(RenderPassColorAttachment {
             view: destination,
             depth_slice: None,
@@ -323,9 +328,15 @@ pub fn fullscreen_material_system<T: FullscreenMaterial>(
     };
 
     {
+        let diagnostics = ctx.diagnostic_recorder();
+        let diagnostics = diagnostics.as_deref();
+
         let mut render_pass = ctx.command_encoder().begin_render_pass(&pass_descriptor);
+        let pass_span = diagnostics.pass_span(&mut render_pass, pass_label.clone());
+
         render_pass.set_pipeline(pipeline);
         render_pass.set_bind_group(0, bind_group, &[settings_index.index()]);
         render_pass.draw(0..3, 0..1);
+        pass_span.end(&mut render_pass);
     }
 }

--- a/crates/bevy_core_pipeline/src/mip_generation/experimental/depth.rs
+++ b/crates/bevy_core_pipeline/src/mip_generation/experimental/depth.rs
@@ -21,6 +21,7 @@ use bevy_log::debug;
 use bevy_math::{uvec2, UVec2, Vec4Swizzles as _};
 use bevy_render::{
     batching::gpu_preprocessing::GpuPreprocessingSupport,
+    diagnostic::RecordDiagnostics,
     occlusion_culling::{
         OcclusionCulling, OcclusionCullingSubview, OcclusionCullingSubviewEntities,
     },
@@ -87,6 +88,13 @@ pub fn early_downsample_depth(
         maybe_view_light_entities,
     ) = view.into_inner();
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+    let time_span = diagnostics.time_span(
+        ctx.command_encoder(),
+        "mip_generation::early_downsample_depth",
+    );
+
     // Downsample depth for the main Z-buffer.
     downsample_depth(
         "early_downsample_depth",
@@ -122,6 +130,7 @@ pub fn early_downsample_depth(
             );
         }
     }
+    time_span.end(ctx.command_encoder());
 }
 
 /// Produces a hierarchical Z-buffer (depth pyramid) for occlusion culling.

--- a/crates/bevy_core_pipeline/src/oit/resolve/oit_resolve.wesl
+++ b/crates/bevy_core_pipeline/src/oit/resolve/oit_resolve.wesl
@@ -60,7 +60,7 @@ fn resolve(head: u32, opaque_depth: f32) -> vec4<f32> {
     var fragment_list: array<OitFragment, SORTED_FRAGMENT_MAX_COUNT>;
     var final_color = vec4<f32>(0.0);
 
-    var packed_opaque_depth = bevy_core_pipeline::oit::draw::pack_24bit_depth_8bit_alpha(opaque_depth, 1.0);
+    var packed_opaque_depth = package::oit::draw::pack_24bit_depth_8bit_alpha(opaque_depth, 1.0);
 
     // fill list
     var current_node = head;
@@ -132,5 +132,5 @@ fn blend(color_a: vec4<f32>, color_b: vec4<f32>) -> vec4<f32> {
 }
 
 fn packed_depth_alpha_get_alpha(packed: u32) -> f32 {
-    return bevy_core_pipeline::oit::draw::unpack_24bit_depth_8bit_alpha(packed).y;
+    return package::oit::draw::unpack_24bit_depth_8bit_alpha(packed).y;
 }

--- a/crates/bevy_core_pipeline/src/prepass/background_motion_vectors.wesl
+++ b/crates/bevy_core_pipeline/src/prepass/background_motion_vectors.wesl
@@ -1,5 +1,5 @@
 import bevy_render::view::View;
-import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
+import package::fullscreen_vertex_shader::FullscreenVertexOutput;
 import bevy_pbr::render::view_transformations::uv_to_ndc;
 
 struct PreviousViewUniforms {

--- a/crates/bevy_core_pipeline/src/schedule.rs
+++ b/crates/bevy_core_pipeline/src/schedule.rs
@@ -23,6 +23,7 @@ use bevy_log::info_span;
 use bevy_reflect::Reflect;
 use bevy_render::{
     camera::{ExtractedCamera, SortedCameras},
+    diagnostic::{DiagnosticsRecorder, RecordDiagnostics},
     render_resource::{
         CommandEncoderDescriptor, LoadOp, Operations, RenderPassColorAttachment,
         RenderPassDescriptor, StoreOp,
@@ -152,6 +153,33 @@ pub fn camera_driver(
 
     let mut camera_windows = EntityHashSet::default();
 
+    let diagnostics_enabled = world.contains_resource::<DiagnosticsRecorder>();
+    let mut reached_root_camera = false;
+    if diagnostics_enabled {
+        let device = world.resource::<RenderDevice>().clone();
+        let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor {
+            label: Some("camera_driver_diagnostic_span"),
+        });
+        world
+            .resource::<DiagnosticsRecorder>()
+            .begin_time_span(&mut encoder, "auxiliary_views".into());
+        world
+            .resource_mut::<PendingCommandBuffers>()
+            .push_encoder(encoder, "camera_driver_span_begin");
+    }
+    let end_time_span = |world: &mut World| {
+        let device = world.resource::<RenderDevice>().clone();
+        let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor {
+            label: Some("camera_driver_diagnostic_span"),
+        });
+        world
+            .resource::<DiagnosticsRecorder>()
+            .end_time_span(&mut encoder);
+        world
+            .resource_mut::<PendingCommandBuffers>()
+            .push_encoder(encoder, "camera_driver_span_end");
+    };
+
     for root_view in root_views {
         let mut run_schedule = true;
         let (schedule, view_entity);
@@ -161,6 +189,10 @@ pub fn camera_driver(
                 entity: camera_entity,
                 ..
             } => {
+                if diagnostics_enabled && !reached_root_camera {
+                    reached_root_camera = true;
+                    end_time_span(world);
+                }
                 let Some(camera) = world.get::<ExtractedCamera>(camera_entity) else {
                     continue;
                 };
@@ -206,6 +238,10 @@ pub fn camera_driver(
             world.run_schedule(schedule);
         }
     }
+    if diagnostics_enabled && !reached_root_camera {
+        end_time_span(world);
+    }
+
     world.remove_resource::<CurrentView>();
 
     world.insert_resource(CameraWindows(camera_windows));

--- a/crates/bevy_core_pipeline/src/tonemapping.wesl
+++ b/crates/bevy_core_pipeline/src/tonemapping.wesl
@@ -4,7 +4,7 @@ import bevy_render::{
     maths::{PI_2, powsafe},
 };
 
-import bevy_core_pipeline::tonemapping::lut_bindings::{
+import package::tonemapping::lut_bindings::{
     dt_lut_texture,
     dt_lut_sampler,
 };

--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping_frag.wesl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping_frag.wesl
@@ -2,7 +2,7 @@ import bevy_render::{
     view::View,
     maths::powsafe,
 };
-import bevy_core_pipeline::{
+import package::{
     fullscreen_vertex_shader::FullscreenVertexOutput,
     tonemapping::{tone_mapping, screen_space_dither},
 };

--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -300,7 +300,7 @@ fn toggle_display(
         let font_size = overlay_config
             .text_config
             .font_size
-            .eval(text_node.1.logical_size(), rem_size.0);
+            .eval(text_node.1.logical_size(), *rem_size);
         graph_node.width = Val::Px(font_size * FRAME_TIME_GRAPH_WIDTH_SCALE);
         graph_node.height = Val::Px(font_size * FRAME_TIME_GRAPH_HEIGHT_SCALE);
 

--- a/crates/bevy_ecs/macro_logic/src/component.rs
+++ b/crates/bevy_ecs/macro_logic/src/component.rs
@@ -229,9 +229,7 @@ impl DeriveComponent {
         // If this component has a summary tick, define the appropriate method.
         let has_summary_tick = if self.summary_tick {
             quote! {
-                fn has_summary_tick() -> bool {
-                    true
-                }
+                const HAS_SUMMARY_TICK: bool = true;
             }
         } else {
             quote! {}

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -270,7 +270,7 @@ impl ComponentDescriptor {
 
     /// Create a new `ComponentDescriptor` for the type `T`.
     pub fn new<T: Component>() -> Self {
-        let summary_tick = T::has_summary_tick();
+        let summary_tick = T::HAS_SUMMARY_TICK;
         assert!(
             !summary_tick || matches!(T::STORAGE_TYPE, StorageType::Table),
             "Summary ticks are only supported for table components"

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -674,7 +674,7 @@ pub trait Component: Send + Sync + 'static {
         None
     }
 
-    /// Return true from this method if the component should track a summary
+    /// Set this constant to true if the component should track a summary
     /// tick.
     ///
     /// Summary ticks allow users of contiguous iteration queries to skip
@@ -687,11 +687,8 @@ pub trait Component: Send + Sync + 'static {
     /// Summary ticks are only valid for table components. If the component is a
     /// sparse set component, this method must return false.
     ///
-    /// By default, this method returns false.
-    #[inline]
-    fn has_summary_tick() -> bool {
-        false
-    }
+    /// By default, this constant is set to false.
+    const HAS_SUMMARY_TICK: bool = false;
 }
 
 mod private {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2528,6 +2528,13 @@ unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for &'__w mut T 
                 // SAFETY: The caller ensures `table_row` is in range.
                 let caller =
                     callers.map(|callers| unsafe { callers.get_unchecked(table_row.index()) });
+                // Make it statically known whether the atomic tick is present or not.
+                let summary_tick = if T::HAS_SUMMARY_TICK {
+                    // SAFETY: Summary tick presence always matches `T::HAS_SUMMARY_TICK`.
+                    Some(unsafe { summary_tick.debug_checked_unwrap() })
+                } else {
+                    None
+                };
 
                 Mut {
                     value: component.deref_mut(),

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -187,12 +187,16 @@ impl Column {
         caller: MaybeLocation,
     ) {
         self.data.initialize_unchecked(row.index(), data);
-        *self.added_ticks.get_unchecked_mut(row.index()).get_mut() = tick;
-        *self.changed_ticks.get_unchecked_mut(row.index()).get_mut() = tick;
+        self.added_ticks
+            .initialize_unchecked(row.index(), UnsafeCell::new(tick));
+        self.changed_ticks
+            .initialize_unchecked(row.index(), UnsafeCell::new(tick));
         self.changed_by
             .as_mut()
-            .map(|changed_by| changed_by.get_unchecked_mut(row.index()).get_mut())
-            .assign(caller);
+            .zip(caller)
+            .map(|(changed_by, caller)| {
+                changed_by.initialize_unchecked(row.index(), UnsafeCell::new(caller));
+            });
         if let Some(summary_tick) = &self.summary_tick {
             summary_tick.set(tick);
         }

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -491,25 +491,10 @@ impl Table {
     /// The allocated row must be written to immediately with valid values in each column
     pub(crate) unsafe fn allocate(&mut self, entity: Entity) -> TableRow {
         self.reserve(1);
-        let len = self.entity_count();
         // SAFETY: No entity index may be in more than one table row at once, so there are no duplicates,
         // and there can not be an entity index of u32::MAX. Therefore, this can not be max either.
-        let row = unsafe { TableRow::new(NonMaxU32::new_unchecked(len)) };
-        let len = len as usize;
+        let row = unsafe { TableRow::new(NonMaxU32::new_unchecked(self.entity_count())) };
         self.entities.push(entity);
-        for col in self.columns.values_mut() {
-            col.added_ticks
-                .initialize_unchecked(len, UnsafeCell::new(Tick::new(0)));
-            col.changed_ticks
-                .initialize_unchecked(len, UnsafeCell::new(Tick::new(0)));
-            col.changed_by
-                .as_mut()
-                .zip(MaybeLocation::caller())
-                .map(|(changed_by, caller)| {
-                    changed_by.initialize_unchecked(len, UnsafeCell::new(caller));
-                });
-        }
-
         row
     }
 

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -550,7 +550,8 @@ where
         .draw_arrow(true);
 
         // draw the plane line
-        let direction = Dir2::new_unchecked(-normal.perp());
+        let direction = -normal.perpendicular();
+
         self.primitive_2d(&Line2d { direction }, isometry, polymorphic_color)
             .draw_arrow(false);
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -333,6 +333,11 @@ bevy_dev_tools = ["dep:bevy_dev_tools"]
 bevy_camera_controller = ["dep:bevy_camera_controller"]
 free_camera = ["bevy_camera_controller/free_camera"]
 pan_camera = ["bevy_camera_controller/pan_camera"]
+pan_orbit_camera = [
+  "bevy_camera_controller/pan_orbit_camera",
+  "bevy_camera_controller/extension_anchor_indicator",
+  "bevy_camera_controller/extension_independent_skybox",
+]
 
 # Enable support for the Bevy Remote Protocol
 bevy_remote = ["dep:bevy_remote", "serialize"]

--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -434,6 +434,8 @@ pub trait StableInterpolate: Clone {
 
     /// A version of [`interpolate_stable`] that assigns the result to `self` for convenience.
     ///
+    /// A manual implementation can be provided to optimize in-place mutation, such as avoiding memory allocations.
+    ///
     /// [`interpolate_stable`]: StableInterpolate::interpolate_stable
     fn interpolate_stable_assign(&mut self, other: &Self, t: f32) {
         *self = self.interpolate_stable(other, t);
@@ -587,12 +589,39 @@ pub trait TryStableInterpolate: Clone {
     /// Attempt to interpolate the value. This may fail if the two interpolation values have
     /// different units, or if the type is not interpolable.
     fn try_interpolate_stable(&self, other: &Self, t: f32) -> Result<Self, Self::Error>;
+
+    /// A version of [`try_interpolate_stable`] that assigns the result to `self` for convenience.
+    /// On failure, `self` remains unchanged.
+    ///
+    /// A manual implementation can be provided to optimize in-place mutation, such as avoiding memory allocations.
+    ///
+    /// [`try_interpolate_stable`]: TryStableInterpolate::try_interpolate_stable
+    fn try_interpolate_stable_assign(&mut self, other: &Self, t: f32) -> Result<(), Self::Error> {
+        *self = self.try_interpolate_stable(other, t)?;
+        Ok(())
+    }
+
+    /// Like [`StableInterpolate::smooth_nudge`] but fallible.
+    fn try_smooth_nudge(
+        &mut self,
+        target: &Self,
+        decay_rate: f32,
+        delta: f32,
+    ) -> Result<(), Self::Error> {
+        self.try_interpolate_stable_assign(target, 1.0 - ops::exp(-decay_rate * delta))?;
+        Ok(())
+    }
 }
 
 impl<T: StableInterpolate> TryStableInterpolate for T {
     type Error = Infallible;
     fn try_interpolate_stable(&self, other: &Self, t: f32) -> Result<Self, Self::Error> {
         Ok(self.interpolate_stable(other, t))
+    }
+
+    fn try_interpolate_stable_assign(&mut self, other: &Self, t: f32) -> Result<(), Self::Error> {
+        self.interpolate_stable_assign(other, t);
+        Ok(())
     }
 }
 
@@ -617,6 +646,19 @@ impl<E, T: TryStableInterpolate<Error = E>> TryStableInterpolate for alloc::vec:
                 .map(|i| self[i].try_interpolate_stable(&other[i], t))
                 .collect::<Result<alloc::vec::Vec<_>, _>>()
                 .map_err(VecInterpolateError::Inner)
+        } else {
+            Err(VecInterpolateError::MismatchedLength)
+        }
+    }
+
+    fn try_interpolate_stable_assign(&mut self, other: &Self, t: f32) -> Result<(), Self::Error> {
+        if self.len() == other.len() {
+            for i in 0..self.len() {
+                self[i]
+                    .try_interpolate_stable_assign(&other[i], t)
+                    .map_err(VecInterpolateError::Inner)?;
+            }
+            Ok(())
         } else {
             Err(VecInterpolateError::MismatchedLength)
         }
@@ -696,17 +738,24 @@ mod tests {
 
     #[test]
     fn interpolate_dynamic_arrays() {
-        let a = vec![0.0, 1.0];
+        let mut a = vec![0.0, 1.0];
         let b = vec![1.0, 0.0];
 
         assert_matches!(a.try_interpolate_stable(&b, 0.25), Ok(v) if v == vec![0.25, 0.75]);
         assert_matches!(a.try_interpolate_stable(&b, 0.5), Ok(v) if v == vec![0.5, 0.5]);
         assert_matches!(a.try_interpolate_stable(&b, 0.75), Ok(v) if v == vec![0.75, 0.25]);
+
+        assert_matches!(a.try_interpolate_stable_assign(&b, 0.25), Ok(()));
+        assert_eq!(a, vec![0.25, 0.75]);
+        assert_matches!(a.try_interpolate_stable_assign(&b, 0.5), Ok(()));
+        assert_eq!(a, vec![0.625, 0.375]);
+        assert_matches!(a.try_interpolate_stable_assign(&b, 0.75), Ok(()));
+        assert_eq!(a, vec![0.90625, 0.09375]);
     }
 
     #[test]
     fn interpolate_dynamic_arrays_different_lengths() {
-        let a = vec![0.0, 1.0];
+        let mut a = vec![0.0, 1.0];
         let b = vec![1.0, 0.0, 1.0];
 
         assert_matches!(
@@ -714,11 +763,23 @@ mod tests {
             Err(VecInterpolateError::MismatchedLength)
         );
 
-        let a: Vec<Vec<f32>> = vec![vec![0.0, 1.0], vec![1.0, 0.0]];
+        assert_matches!(
+            a.try_interpolate_stable_assign(&b, 0.5),
+            Err(VecInterpolateError::MismatchedLength)
+        );
+
+        let mut a: Vec<Vec<f32>> = vec![vec![0.0, 1.0], vec![1.0, 0.0]];
         let b: Vec<Vec<f32>> = vec![vec![1.0, 0.0], vec![0.0, 1.0, 0.0]];
 
         assert_matches!(
             a.try_interpolate_stable(&b, 0.5),
+            Err(VecInterpolateError::Inner(
+                VecInterpolateError::MismatchedLength
+            ))
+        );
+
+        assert_matches!(
+            a.try_interpolate_stable_assign(&b, 0.5),
             Err(VecInterpolateError::Inner(
                 VecInterpolateError::MismatchedLength
             ))

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -292,6 +292,12 @@ impl Dir2 {
         // Based on a Taylor approximation of the inverse square root, see [`Dir3::fast_renormalize`] for more details.
         Self(self * (0.5 * (3.0 - length_squared)))
     }
+
+    /// Returns the perpendicular vector rotated to 90 degrees counterclockwise.
+    #[inline]
+    pub fn perpendicular(self) -> Self {
+        Self::new_unchecked(self.as_vec2().perp())
+    }
 }
 
 impl TryFrom<Vec2> for Dir2 {
@@ -1321,6 +1327,21 @@ mod tests {
             "Denormalization doesn't work, test is faulty"
         );
         assert!(dir_b.is_normalized(), "Renormalisation did not work.");
+    }
+
+    #[test]
+    fn dir2_perp() {
+        // (1, 0) rotated 90 deg counterclockwise becomes (0, 1)
+        assert_eq!(Dir2::X.perpendicular(), Dir2::Y);
+
+        // (0, 1) rotated 90 deg counterclockwise becomes (-1, 0)
+        assert_eq!(Dir2::Y.perpendicular(), Dir2::NEG_X);
+
+        // (-1, 0) rotated 90 deg counterclockwise becomes (0, -1)
+        assert_eq!(Dir2::NEG_X.perpendicular(), Dir2::NEG_Y);
+
+        // (0, -1) rotated 90 deg counterclockwise becomes (1, 0)
+        assert_eq!(Dir2::NEG_Y.perpendicular(), Dir2::X);
     }
 
     #[test]

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -55,6 +55,7 @@ pub use compass::{CompassOctant, CompassQuadrant};
 pub use direction::*;
 pub use float_ord::*;
 pub use glam::camera::rh::proj::directx as proj;
+pub use glam::dcamera::rh::proj::directx as dproj;
 pub use isometry::{Isometry2d, Isometry3d};
 pub use mat3::*;
 pub use ops::FloatPow;

--- a/crates/bevy_pbr/src/atmosphere/aerial_view_lut.wesl
+++ b/crates/bevy_pbr/src/atmosphere/aerial_view_lut.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     atmosphere::{
         bindings::settings,
         functions::{

--- a/crates/bevy_pbr/src/atmosphere/bindings.wesl
+++ b/crates/bevy_pbr/src/atmosphere/bindings.wesl
@@ -1,6 +1,6 @@
 import bevy_render::view::View;
 
-import bevy_pbr::{
+import package::{
     render::mesh_view_types::Lights,
     atmosphere::types::{Atmosphere, AtmosphereSettings, AtmosphereTransforms}
 };

--- a/crates/bevy_pbr/src/atmosphere/bruneton_functions.wesl
+++ b/crates/bevy_pbr/src/atmosphere/bruneton_functions.wesl
@@ -53,7 +53,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     types::Atmosphere,
     bindings::atmosphere,
     functions::{get_local_r, sample_transmittance_lut},

--- a/crates/bevy_pbr/src/atmosphere/environment.rs
+++ b/crates/bevy_pbr/src/atmosphere/environment.rs
@@ -18,6 +18,7 @@ use bevy_image::Image;
 use bevy_light::{AtmosphereEnvironmentMapLight, GeneratedEnvironmentMapLight};
 use bevy_math::{Quat, UVec2};
 use bevy_render::{
+    diagnostic::RecordDiagnostics,
     extract_component::{ComponentUniforms, DynamicUniformIndex, ExtractComponent},
     render_asset::RenderAssets,
     render_resource::{binding_types::*, *},
@@ -270,6 +271,10 @@ pub fn atmosphere_environment(
         lights_uniforms_offset,
     ) = view.into_inner();
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+    let time_span = diagnostics.time_span(ctx.command_encoder(), "atmosphere_environment");
+
     for (bind_groups, env_map_light) in probe_query.iter() {
         let command_encoder = ctx.command_encoder();
         let mut pass = command_encoder.begin_compute_pass(&ComputePassDescriptor {
@@ -296,4 +301,6 @@ pub fn atmosphere_environment(
             6, // 6 cubemap faces
         );
     }
+
+    time_span.end(ctx.command_encoder());
 }

--- a/crates/bevy_pbr/src/atmosphere/environment.wesl
+++ b/crates/bevy_pbr/src/atmosphere/environment.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     atmosphere::{
         functions::{direction_world_to_atmosphere, sample_sky_view_lut, get_view_position},
     },

--- a/crates/bevy_pbr/src/atmosphere/functions.wesl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wesl
@@ -1,6 +1,6 @@
 import bevy_render::maths::{PI, HALF_PI, PI_2, fast_acos, fast_acos_4, fast_atan2, ray_sphere_intersect};
 
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     types::Atmosphere,
     bindings::{
         atmosphere, settings, view, lights, transmittance_lut, atmosphere_lut_sampler,

--- a/crates/bevy_pbr/src/atmosphere/multiscattering_lut.wesl
+++ b/crates/bevy_pbr/src/atmosphere/multiscattering_lut.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     atmosphere::{
         bindings::{atmosphere, settings},
         functions::{

--- a/crates/bevy_pbr/src/atmosphere/node.rs
+++ b/crates/bevy_pbr/src/atmosphere/node.rs
@@ -3,6 +3,7 @@ use bevy_ecs::system::Res;
 use bevy_math::{UVec2, Vec3Swizzles};
 use bevy_render::{
     camera::ExtractedCamera,
+    diagnostic::RecordDiagnostics,
     extract_component::DynamicUniformIndex,
     render_resource::{ComputePass, ComputePassDescriptor, PipelineCache, RenderPassDescriptor},
     renderer::{RenderContext, ViewQuery},
@@ -58,12 +59,16 @@ pub fn atmosphere_luts(
         return;
     };
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+
     let command_encoder = ctx.command_encoder();
 
     let mut luts_pass = command_encoder.begin_compute_pass(&ComputePassDescriptor {
         label: Some("atmosphere_luts"),
         timestamp_writes: None,
     });
+    let pass_span = diagnostics.pass_span(&mut luts_pass, "atmosphere_luts");
 
     fn dispatch_2d(compute_pass: &mut ComputePass, size: UVec2) {
         const WORKGROUP_SIZE: u32 = 16;
@@ -136,6 +141,7 @@ pub fn atmosphere_luts(
     );
 
     dispatch_2d(&mut luts_pass, settings.aerial_view_lut_size.xy());
+    pass_span.end(&mut luts_pass);
 }
 
 pub fn render_sky(
@@ -172,6 +178,9 @@ pub fn render_sky(
         return;
     }; //TODO: warning
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+
     let command_encoder = ctx.command_encoder();
 
     let mut render_sky_pass = command_encoder.begin_render_pass(&RenderPassDescriptor {
@@ -182,6 +191,7 @@ pub fn render_sky(
         occlusion_query_set: None,
         multiview_mask: None,
     });
+    let pass_span = diagnostics.pass_span(&mut render_sky_pass, "render_sky");
 
     if let Some(viewport) =
         Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)
@@ -209,4 +219,5 @@ pub fn render_sky(
         ],
     );
     render_sky_pass.draw(0..3, 0..1);
+    pass_span.end(&mut render_sky_pass);
 }

--- a/crates/bevy_pbr/src/atmosphere/render_sky.wesl
+++ b/crates/bevy_pbr/src/atmosphere/render_sky.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     bindings::{view, settings},
     bruneton_functions::sample_transmittance_lut_segment,
     functions::{

--- a/crates/bevy_pbr/src/atmosphere/sky_view_lut.wesl
+++ b/crates/bevy_pbr/src/atmosphere/sky_view_lut.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     atmosphere::{
         bindings::settings,
         functions::{

--- a/crates/bevy_pbr/src/atmosphere/transmittance_lut.wesl
+++ b/crates/bevy_pbr/src/atmosphere/transmittance_lut.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     bindings::settings,
     functions::{
         sample_density_lut, get_local_r, max_atmosphere_distance,

--- a/crates/bevy_pbr/src/cluster.wesl
+++ b/crates/bevy_pbr/src/cluster.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::clustered_forward::view_z_to_z_slice;
+import package::render::clustered_forward::view_z_to_z_slice;
 
 // Valid values for the `object_type` field.
 const CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT: u32 = 0u;

--- a/crates/bevy_pbr/src/cluster/cluster_allocate.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_allocate.wesl
@@ -1,5 +1,5 @@
-import bevy_pbr::cluster::ClusterMetadata;
-import bevy_pbr::render::mesh_view_types::{ClusterOffsetsAndCounts, Lights};
+import package::cluster::ClusterMetadata;
+import package::render::mesh_view_types::{ClusterOffsetsAndCounts, Lights};
 
 // The shader that allocates the clustered object ID buffer.
 //

--- a/crates/bevy_pbr/src/cluster/cluster_raster.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_raster.wesl
@@ -1,12 +1,12 @@
-import bevy_pbr::cluster::{
+import package::cluster::{
     Aabb, CLUSTERABLE_OBJECT_TYPE_DECAL, CLUSTERABLE_OBJECT_TYPE_IRRADIANCE_VOLUME,
     CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT, CLUSTERABLE_OBJECT_TYPE_REFLECTION_PROBE,
     CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, ClusterableObjectZSlice,
     calculate_sphere_cluster_bounds, compute_view_from_world_scale
 };
-import bevy_pbr::render::clustered_forward;
-import bevy_pbr::light_probe::transpose_affine_matrix;
-import bevy_pbr::render::mesh_view_types::{
+import package::render::clustered_forward;
+import package::light_probe::transpose_affine_matrix;
+import package::render::mesh_view_types::{
     ClusterOffsetsAndCounts, ClusterableObjectIndexLists, ClusteredDecals, ClusteredLights,
     LightProbes, Lights, POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE
 };

--- a/crates/bevy_pbr/src/cluster/cluster_z_slice.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_z_slice.wesl
@@ -1,10 +1,10 @@
-import bevy_pbr::cluster::{
+import package::cluster::{
     CLUSTERABLE_OBJECT_TYPE_DECAL, CLUSTERABLE_OBJECT_TYPE_IRRADIANCE_VOLUME,
     CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT, CLUSTERABLE_OBJECT_TYPE_REFLECTION_PROBE,
     CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, ClusterMetadata, ClusterableObjectZSlice,
     calculate_sphere_cluster_bounds, compute_view_from_world_scale
 };
-import bevy_pbr::render::mesh_view_types::{
+import package::render::mesh_view_types::{
     ClusteredDecals, ClusteredLights, LightProbes, Lights, POINT_LIGHT_FLAGS_SPOT_LIGHT_BIT
 };
 import bevy_render::view::View;

--- a/crates/bevy_pbr/src/cluster/gpu.rs
+++ b/crates/bevy_pbr/src/cluster/gpu.rs
@@ -1675,7 +1675,8 @@ pub(crate) fn prepare_clusters_for_gpu_clustering(
             Some(view_irradiance_volumes) => view_irradiance_volumes.len() as u32,
             None => 0,
         };
-        let decal_count = render_clustered_decals.len() as u32;
+        // Light textures share the decal buffer but aren't clusterable objects.
+        let decal_count = render_clustered_decals.clusterable_decal_count() as u32;
 
         // Initialize the metadata.
         *view_gpu_clustering_buffers

--- a/crates/bevy_pbr/src/decal/clustered.rs
+++ b/crates/bevy_pbr/src/decal/clustered.rs
@@ -75,7 +75,13 @@ pub struct RenderClusteredDecals {
     /// [`Self::binding_index_to_textures`] holds the inverse mapping.
     texture_to_binding_index: HashMap<AssetId<Image>, i32>,
     /// The information concerning each decal that we provide to the shader.
+    ///
+    /// Light textures follow the true clustered decals in this list, so that
+    /// lights can reference them via their decal indices.
     decals: Vec<RenderClusteredDecal>,
+    /// The number of true clustered decals at the start of `decals`. Light
+    /// textures past this count aren't clusterable objects.
+    clusterable_decal_count: usize,
     /// Maps the [`bevy_render::sync_world::RenderEntity`] of each decal to the
     /// index of that decal in the [`Self::decals`] list.
     entity_to_decal_index: EntityHashMap<usize>,
@@ -88,9 +94,14 @@ impl RenderClusteredDecals {
         self.binding_index_to_textures.clear();
         self.texture_to_binding_index.clear();
         self.decals.clear();
+        self.clusterable_decal_count = 0;
         self.entity_to_decal_index.clear();
     }
 
+    /// Inserts a decal into the buffer, along with its associated textures.
+    ///
+    /// Decals inserted this way aren't assigned to clusters; use the
+    /// [`bevy_light::ClusteredDecal`] component for clusterable decals.
     pub fn insert_decal(
         &mut self,
         entity: Entity,
@@ -122,14 +133,20 @@ impl RenderClusteredDecals {
         self.entity_to_decal_index.get(&entity).copied()
     }
 
-    /// Returns the number of clustered decals in the scene.
+    /// Returns the number of entries in the decal buffer, light textures included.
     pub fn len(&self) -> usize {
         self.decals.len()
     }
 
-    /// Returns true if there are no clustered decals in the scene.
+    /// Returns true if there are no entries in the decal buffer.
     pub fn is_empty(&self) -> bool {
         self.decals.is_empty()
+    }
+
+    /// Returns the number of true clustered decals in the scene, excluding
+    /// light textures, which aren't clusterable objects.
+    pub(crate) fn clusterable_decal_count(&self) -> usize {
+        self.clusterable_decal_count
     }
 }
 
@@ -273,6 +290,11 @@ pub fn extract_decals(
     render_decals.clear();
 
     extract_clustered_decals(&decals, &mut render_decals);
+
+    // Light textures follow the true clustered decals in the buffer, but
+    // aren't clusterable objects. Record where they start.
+    render_decals.clusterable_decal_count = render_decals.decals.len();
+
     extract_spot_light_textures(&spot_light_textures, &mut render_decals);
     extract_point_light_textures(&point_light_textures, &mut render_decals);
     extract_directional_light_textures(&directional_light_textures, &mut render_decals);

--- a/crates/bevy_pbr/src/decal/clustered.wesl
+++ b/crates/bevy_pbr/src/decal/clustered.wesl
@@ -26,17 +26,17 @@
 // Note that the order in which decals are returned is currently unpredictable,
 // though generally stable from frame to frame.
 
-import bevy_pbr::render::clustered_forward;
-import bevy_pbr::render::clustered_forward::ClusterableObjectIndexRanges;
-import bevy_pbr::render::mesh_view_bindings;
-import bevy_pbr::render::pbr_functions;
-import bevy_pbr::render::pbr_types::PbrInput;
-import bevy_pbr::render::utils::porter_duff_over;
+import package::render::clustered_forward;
+import package::render::clustered_forward::ClusterableObjectIndexRanges;
+import package::render::mesh_view_bindings;
+import package::render::pbr_functions;
+import package::render::pbr_types::PbrInput;
+import package::render::utils::porter_duff_over;
 import bevy_render::maths;
 
-@if(MESHLET_MESH_MATERIAL_PASS) import bevy_pbr::meshlet::visibility_buffer_resolve::VertexOutput;
-@elif(PREPASS_PIPELINE) import bevy_pbr::prepass::io::VertexOutput;
-@else import bevy_pbr::render::forward_io::VertexOutput;
+@if(MESHLET_MESH_MATERIAL_PASS) import package::meshlet::visibility_buffer_resolve::VertexOutput;
+@elif(PREPASS_PIPELINE) import package::prepass::io::VertexOutput;
+@else import package::render::forward_io::VertexOutput;
 
 // An object that allows stepping through all clustered decals that affect a
 // single fragment.

--- a/crates/bevy_pbr/src/decal/forward.wesl
+++ b/crates/bevy_pbr/src/decal/forward.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         forward_io::VertexOutput,
         mesh_functions::get_world_from_local,

--- a/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
+++ b/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     prepass::utils as prepass_utils,
     render::{
         pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT,
@@ -12,8 +12,8 @@ import bevy_pbr::{
     },
 };
 
-@if(SCREEN_SPACE_AMBIENT_OCCLUSION) import bevy_pbr::render::mesh_view_bindings::screen_space_ambient_occlusion_texture;
-@if(SCREEN_SPACE_AMBIENT_OCCLUSION) import bevy_pbr::ssao::utils::ssao_multibounce;
+@if(SCREEN_SPACE_AMBIENT_OCCLUSION) import package::render::mesh_view_bindings::screen_space_ambient_occlusion_texture;
+@if(SCREEN_SPACE_AMBIENT_OCCLUSION) import package::ssao::utils::ssao_multibounce;
 
 struct FullscreenVertexOutput {
     @builtin(position)

--- a/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
+++ b/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
@@ -63,7 +63,8 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     if ((pbr_input.material.flags & STANDARD_MATERIAL_FLAGS_UNLIT_BIT) == 0u) {
 
 @if(SCREEN_SPACE_AMBIENT_OCCLUSION) {
-        let ssao = textureLoad(screen_space_ambient_occlusion_texture, vec2<i32>(in.position.xy), 0i).r;
+        let ssao_tex_pos = vec2<i32>(in.position.xy - view.viewport.xy);
+        let ssao = textureLoad(screen_space_ambient_occlusion_texture, ssao_tex_pos, 0i).r;
         let ssao_multibounce = ssao_multibounce(ssao, pbr_input.material.base_color.rgb);
         pbr_input.diffuse_occlusion = min(pbr_input.diffuse_occlusion, ssao_multibounce);
 

--- a/crates/bevy_pbr/src/deferred/functions.wesl
+++ b/crates/bevy_pbr/src/deferred/functions.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_types::{PbrInput, pbr_input_new, STANDARD_MATERIAL_FLAGS_UNLIT_BIT},
         pbr_functions,
@@ -11,11 +11,11 @@ import bevy_pbr::{
 };
 import bevy_render::utils::{octahedral_encode, octahedral_decode};
 
-@if(MESHLET_MESH_MATERIAL_PASS) import bevy_pbr::meshlet::visibility_buffer_resolve::VertexOutput;
-@else import bevy_pbr::prepass::io::VertexOutput;
+@if(MESHLET_MESH_MATERIAL_PASS) import package::meshlet::visibility_buffer_resolve::VertexOutput;
+@else import package::prepass::io::VertexOutput;
 
 @if(MOTION_VECTOR_PREPASS)
-    import bevy_pbr::render::pbr_prepass_functions::calculate_motion_vector;
+    import package::render::pbr_prepass_functions::calculate_motion_vector;
 
 // Creates the deferred gbuffer from a PbrInput.
 fn deferred_gbuffer_from_pbr_input(in: PbrInput) -> vec4<u32> {

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -16,6 +16,7 @@ use bevy_core_pipeline::{
 use bevy_ecs::prelude::*;
 use bevy_render::{
     camera::ExtractedCamera,
+    diagnostic::RecordDiagnostics,
     extract_component::{
         ComponentUniforms, ExtractComponent, ExtractComponentPlugin, UniformComponentPlugin,
     },
@@ -148,6 +149,9 @@ pub fn deferred_lighting(
         return;
     };
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+
     let bind_group_2 = ctx.render_device().create_bind_group(
         "deferred_lighting_layout_group_2",
         &pipeline_cache.get_bind_group_layout(&deferred_lighting_layout.bind_group_layout_2),
@@ -169,6 +173,7 @@ pub fn deferred_lighting(
         occlusion_query_set: None,
         multiview_mask: None,
     });
+    let pass_span = diagnostics.pass_span(&mut render_pass, "deferred_lighting");
 
     render_pass.set_render_pipeline(pipeline);
 
@@ -180,6 +185,7 @@ pub fn deferred_lighting(
     render_pass.set_bind_group(1, &mesh_view_bind_group.binding_array, &[]);
     render_pass.set_bind_group(2, &bind_group_2, &[]);
     render_pass.draw(0..3, 0..1);
+    pass_span.end(&mut render_pass);
 }
 
 #[derive(Resource)]

--- a/crates/bevy_pbr/src/deferred/types.wesl
+++ b/crates/bevy_pbr/src/deferred/types.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_types::MESH_FLAGS_SHADOW_RECEIVER_BIT,
     pbr_types::{STANDARD_MATERIAL_FLAGS_FOG_ENABLED_BIT, STANDARD_MATERIAL_FLAGS_UNLIT_BIT},
 };

--- a/crates/bevy_pbr/src/light_probe.wesl
+++ b/crates/bevy_pbr/src/light_probe.wesl
@@ -1,7 +1,7 @@
-import bevy_pbr::render::clustered_forward;
-import bevy_pbr::render::clustered_forward::ClusterableObjectIndexRanges;
-import bevy_pbr::render::mesh_view_bindings::light_probes;
-import bevy_pbr::render::mesh_view_types::{
+import package::render::clustered_forward;
+import package::render::clustered_forward::ClusterableObjectIndexRanges;
+import package::render::mesh_view_bindings::light_probes;
+import package::render::mesh_view_types::{
     LightProbe, LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE,
     LIGHT_PROBE_FLAG_PARALLAX_CORRECT
 };

--- a/crates/bevy_pbr/src/light_probe/environment_filter.wesl
+++ b/crates/bevy_pbr/src/light_probe/environment_filter.wesl
@@ -1,5 +1,5 @@
 import bevy_render::maths::PI;
-import bevy_pbr::render::{
+import package::render::{
     pbr_lighting as lighting,
     utils::{sample_cosine_hemisphere, dir_to_cube_uv, sample_cube_dir, hammersley_2d, rand_vec2f}
 };

--- a/crates/bevy_pbr/src/light_probe/environment_map.wesl
+++ b/crates/bevy_pbr/src/light_probe/environment_map.wesl
@@ -1,11 +1,11 @@
-import bevy_pbr::light_probe::{light_probe_iterator_new, light_probe_iterator_next};
-import bevy_pbr::render::mesh_view_bindings as bindings;
-import bevy_pbr::render::mesh_view_bindings::light_probes;
-import bevy_pbr::render::mesh_view_types::{
+import package::light_probe::{light_probe_iterator_new, light_probe_iterator_next};
+import package::render::mesh_view_bindings as bindings;
+import package::render::mesh_view_bindings::light_probes;
+import package::render::mesh_view_types::{
     LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE, LIGHT_PROBE_FLAG_PARALLAX_CORRECT
 };
-import bevy_pbr::render::pbr_lighting::{F_Schlick_vec, LightingInput, LayerLightingInput, LAYER_BASE, LAYER_CLEARCOAT};
-import bevy_pbr::render::clustered_forward::ClusterableObjectIndexRanges;
+import package::render::pbr_lighting::{F_Schlick_vec, LightingInput, LayerLightingInput, LAYER_BASE, LAYER_CLEARCOAT};
+import package::render::clustered_forward::ClusterableObjectIndexRanges;
 
 // The maximum representable value in a 32-bit floating point number.
 const FLOAT_MAX: f32 = 3.40282347e+38;

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.wesl
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.wesl
@@ -1,13 +1,13 @@
-import bevy_pbr::light_probe::{light_probe_iterator_new, light_probe_iterator_next};
-import bevy_pbr::render::mesh_view_bindings::{
+import package::light_probe::{light_probe_iterator_new, light_probe_iterator_next};
+import package::render::mesh_view_bindings::{
     irradiance_volumes,
     irradiance_volume,
     irradiance_volume_sampler,
     light_probes,
 };
-import bevy_pbr::render::clustered_forward::ClusterableObjectIndexRanges;
+import package::render::clustered_forward::ClusterableObjectIndexRanges;
 
-@if(LIGHTMAP) import bevy_pbr::render::mesh_view_types::LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE;
+@if(LIGHTMAP) import package::render::mesh_view_types::LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE;
 
 @if(IRRADIANCE_VOLUMES_ARE_USABLE)
 

--- a/crates/bevy_pbr/src/lightmap.wesl
+++ b/crates/bevy_pbr/src/lightmap.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::mesh_bindings::mesh;
+import package::render::mesh_bindings::mesh;
 
 @if(MULTIPLE_LIGHTMAPS_IN_ARRAY)
 enable wgpu_binding_array;

--- a/crates/bevy_pbr/src/meshlet/bindings.wesl
+++ b/crates/bevy_pbr/src/meshlet/bindings.wesl
@@ -1,6 +1,6 @@
-import bevy_pbr::render::mesh_types::Mesh;
+import package::render::mesh_types::Mesh;
 import bevy_render::view::View;
-import bevy_pbr::prepass::bindings::PreviousViewUniforms;
+import package::prepass::bindings::PreviousViewUniforms;
 import bevy_render::utils::octahedral_decode_signed;
 
 struct BvhNode {

--- a/crates/bevy_pbr/src/meshlet/cull_bvh.wesl
+++ b/crates/bevy_pbr/src/meshlet/cull_bvh.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::meshlet::bindings::{
+import package::meshlet::bindings::{
     InstancedOffset,
     get_aabb,
     get_aabb_error,
@@ -18,7 +18,7 @@ import bevy_pbr::meshlet::bindings::{
     meshlet_second_pass_bvh_dispatch,
     meshlet_second_pass_bvh_queue,
 };
-import bevy_pbr::meshlet::cull_shared::{
+import package::meshlet::cull_shared::{
     lod_error_is_imperceptible,
     aabb_in_frustum,
     should_occlusion_cull_aabb,

--- a/crates/bevy_pbr/src/meshlet/cull_clusters.wesl
+++ b/crates/bevy_pbr/src/meshlet/cull_clusters.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::meshlet::bindings::{
+import package::meshlet::bindings::{
     InstancedOffset,
     get_aabb,
     get_aabb_error,
@@ -15,7 +15,7 @@ import bevy_pbr::meshlet::bindings::{
     meshlet_meshlet_cull_dispatch,
     meshlet_meshlet_cull_queue,
 };
-import bevy_pbr::meshlet::cull_shared::{
+import package::meshlet::cull_shared::{
     ScreenAabb,
     project_aabb,
     lod_error_is_imperceptible,

--- a/crates/bevy_pbr/src/meshlet/cull_instances.wesl
+++ b/crates/bevy_pbr/src/meshlet/cull_instances.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::meshlet::bindings::{
+import package::meshlet::bindings::{
     InstancedOffset,
     constants,
     meshlet_view_instance_visibility,
@@ -11,7 +11,7 @@ import bevy_pbr::meshlet::bindings::{
     meshlet_second_pass_instance_dispatch,
     meshlet_second_pass_instance_candidates,
 };
-import bevy_pbr::meshlet::cull_shared::{
+import package::meshlet::cull_shared::{
     aabb_in_frustum,
     should_occlusion_cull_aabb,
 };

--- a/crates/bevy_pbr/src/meshlet/cull_shared.wesl
+++ b/crates/bevy_pbr/src/meshlet/cull_shared.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::meshlet::bindings::{
+import package::meshlet::bindings::{
     MeshletAabb,
     DispatchIndirectArgs,
     InstancedOffset,

--- a/crates/bevy_pbr/src/meshlet/material_shade_nodes.rs
+++ b/crates/bevy_pbr/src/meshlet/material_shade_nodes.rs
@@ -15,6 +15,7 @@ use bevy_core_pipeline::prepass::{
 use bevy_ecs::{prelude::*, query::Has};
 use bevy_render::{
     camera::ExtractedCamera,
+    diagnostic::RecordDiagnostics,
     render_resource::{
         LoadOp, Operations, PipelineCache, RenderPassDepthStencilAttachment, RenderPassDescriptor,
         StoreOp,
@@ -60,6 +61,9 @@ pub fn meshlet_main_opaque_pass(
         return;
     };
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+
     let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
         label: Some("meshlet_material_opaque_3d_pass"),
         color_attachments: &[Some(target.get_color_attachment())],
@@ -75,6 +79,7 @@ pub fn meshlet_main_opaque_pass(
         occlusion_query_set: None,
         multiview_mask: None,
     });
+    let pass_span = diagnostics.pass_span(&mut render_pass, "meshlet_material_opaque_3d_pass");
 
     if let Some(viewport) =
         Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)
@@ -102,6 +107,7 @@ pub fn meshlet_main_opaque_pass(
             render_pass.draw(x..(x + 3), 0..1);
         }
     }
+    pass_span.end(&mut render_pass);
 }
 
 ///
@@ -160,6 +166,9 @@ pub fn meshlet_prepass(
         None,
     ];
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+
     let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
         label: Some("meshlet_material_prepass"),
         color_attachments: &color_attachments,
@@ -175,6 +184,7 @@ pub fn meshlet_prepass(
         occlusion_query_set: None,
         multiview_mask: None,
     });
+    let pass_span = diagnostics.pass_span(&mut render_pass, "meshlet_material_prepass");
 
     if let Some(viewport) =
         Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)
@@ -214,6 +224,8 @@ pub fn meshlet_prepass(
             render_pass.draw(x..(x + 3), 0..1);
         }
     }
+
+    pass_span.end(&mut render_pass);
 }
 
 /// Fullscreen pass to generate a gbuffer based on the visibility buffer generated from rasterizing meshlets.
@@ -276,6 +288,9 @@ pub fn meshlet_deferred_gbuffer_prepass(
             .map(|deferred_lighting_pass_id| deferred_lighting_pass_id.get_attachment()),
     ];
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+
     let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
         label: Some("meshlet_material_deferred_prepass"),
         color_attachments: &color_attachments,
@@ -291,6 +306,7 @@ pub fn meshlet_deferred_gbuffer_prepass(
         occlusion_query_set: None,
         multiview_mask: None,
     });
+    let pass_span = diagnostics.pass_span(&mut render_pass, "meshlet_material_deferred_prepass");
 
     if let Some(viewport) =
         Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)
@@ -330,4 +346,6 @@ pub fn meshlet_deferred_gbuffer_prepass(
             render_pass.draw(x..(x + 3), 0..1);
         }
     }
+
+    pass_span.end(&mut render_pass);
 }

--- a/crates/bevy_pbr/src/meshlet/meshlet_mesh_material.wesl
+++ b/crates/bevy_pbr/src/meshlet/meshlet_mesh_material.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     meshlet::visibility_buffer_resolve::resolve_vertex_output,
     prepass::io as prepass_io,
     render::{
@@ -43,7 +43,7 @@ fn prepass_fragment(@builtin(position) frag_coord: vec4<f32>) -> prepass_io::Fra
     // emissive magenta out to the deferred gbuffer to be rendered by the first deferred lighting pass layer.
     // This is here so if the default prepass fragment is used for deferred magenta will be rendered, and also
     // as an example to show that a user could write to the deferred gbuffer if they were to start from this shader.
-    out.deferred = vec4(0u, bevy_pbr::render::rgb9e5::vec3_to_rgb9e5_(vec3(1.0, 0.0, 1.0)), 0u, 0u);
+    out.deferred = vec4(0u, package::render::rgb9e5::vec3_to_rgb9e5_(vec3(1.0, 0.0, 1.0)), 0u, 0u);
     @if(DEFERRED_PREPASS)
     out.deferred_lighting_pass_id = 1u;
 

--- a/crates/bevy_pbr/src/meshlet/resolve_render_targets.wesl
+++ b/crates/bevy_pbr/src/meshlet/resolve_render_targets.wesl
@@ -1,5 +1,5 @@
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
-import bevy_pbr::meshlet::bindings::InstancedOffset;
+import package::meshlet::bindings::InstancedOffset;
 
 @if(MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT)
 @group(0) @binding(0) var meshlet_visibility_buffer: texture_storage_2d<r64uint, read>;

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_hardware_raster.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_hardware_raster.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     meshlet::bindings::{
         meshlet_cluster_meshlet_ids,
         meshlets,

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     meshlet::bindings::{
         Meshlet,
         meshlet_visibility_buffer,
@@ -20,7 +20,7 @@ import bevy_pbr::{
 import bevy_render::maths::{affine3_to_square, mat2x4_f32_to_mat3x3_unpack};
 
 @if(PREPASS_FRAGMENT && MOTION_VECTOR_PREPASS)
-import bevy_pbr::{
+import package::{
     prepass::bindings::previous_view_uniforms,
     render::pbr_prepass_functions::calculate_motion_vector,
 };

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     meshlet::bindings::{
         meshlet_cluster_meshlet_ids,
         meshlets,

--- a/crates/bevy_pbr/src/prepass/io.wesl
+++ b/crates/bevy_pbr/src/prepass/io.wesl
@@ -66,7 +66,7 @@ struct Vertex {
 // The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
 // See https://github.com/gfx-rs/naga/issues/2416
 fn decompress_vertex(vertex_in: Vertex, instance_index: u32) -> UncompressedVertex {
-    let mesh_metadata = bevy_pbr::render::mesh_functions::get_metadata(instance_index);
+    let mesh_metadata = package::render::mesh_functions::get_metadata(instance_index);
     var uncompressed_vertex: UncompressedVertex;
     uncompressed_vertex.instance_index = instance_index;
 @if(VERTEX_POSITIONS_COMPRESSED)

--- a/crates/bevy_pbr/src/prepass/prepass.wesl
+++ b/crates/bevy_pbr/src/prepass/prepass.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     prepass::{
         bindings as prepass_bindings,
         io::{Vertex, UncompressedVertex, VertexOutput, FragmentOutput, decompress_vertex},
@@ -15,7 +15,7 @@ import bevy_pbr::{
 };
 
 @if(DEFERRED_PREPASS)
-import bevy_pbr::render::rgb9e5;
+import package::render::rgb9e5;
 
 @if(MORPH_TARGETS)
 // The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
@@ -202,7 +202,7 @@ fn fragment(in: VertexOutput) -> FragmentOutput {
     // emissive magenta out to the deferred gbuffer to be rendered by the first deferred lighting pass layer.
     // This is here so if the default prepass fragment is used for deferred magenta will be rendered, and also
     // as an example to show that a user could write to the deferred gbuffer if they were to start from this shader.
-    out.deferred = vec4(0u, bevy_pbr::render::rgb9e5::vec3_to_rgb9e5_(vec3(1.0, 0.0, 1.0)), 0u, 0u);
+    out.deferred = vec4(0u, package::render::rgb9e5::vec3_to_rgb9e5_(vec3(1.0, 0.0, 1.0)), 0u, 0u);
     out.deferred_lighting_pass_id = 1u;
 }
 

--- a/crates/bevy_pbr/src/prepass/utils.wesl
+++ b/crates/bevy_pbr/src/prepass/utils.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::mesh_view_bindings as view_bindings;
+import package::render::mesh_view_bindings as view_bindings;
 
 @if(DEPTH_PREPASS)
 fn prepass_depth(frag_coord: vec4<f32>, sample_index: u32) -> f32 {

--- a/crates/bevy_pbr/src/render/clustered_forward.wesl
+++ b/crates/bevy_pbr/src/render/clustered_forward.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_bindings as bindings,
     utils::rand_f,
 };

--- a/crates/bevy_pbr/src/render/fog.wesl
+++ b/crates/bevy_pbr/src/render/fog.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_bindings::fog,
     mesh_view_types::Fog,
 };

--- a/crates/bevy_pbr/src/render/forward_io.wesl
+++ b/crates/bevy_pbr/src/render/forward_io.wesl
@@ -57,7 +57,7 @@ struct Vertex {
 // The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
 // See https://github.com/gfx-rs/naga/issues/2416
 fn decompress_vertex(vertex_in: Vertex, instance_index: u32) -> UncompressedVertex {
-    let mesh_metadata = bevy_pbr::render::mesh_functions::get_metadata(instance_index);
+    let mesh_metadata = package::render::mesh_functions::get_metadata(instance_index);
     var uncompressed_vertex: UncompressedVertex;
     uncompressed_vertex.instance_index = instance_index;
 @if(VERTEX_POSITIONS && VERTEX_POSITIONS_COMPRESSED)

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -43,6 +43,7 @@ use bevy_render::batching::gpu_preprocessing::{
     BuildIndirectParametersMetadata, IndirectParametersBuffers,
 };
 use bevy_render::camera::{DirtySpecializations, PendingQueues};
+use bevy_render::diagnostic::RecordDiagnostics;
 use bevy_render::erased_render_asset::ErasedRenderAssets;
 use bevy_render::mesh::allocator::MeshSlabs;
 use bevy_render::occlusion_culling::{
@@ -2929,6 +2930,10 @@ pub fn per_view_shadow_pass<const IS_LATE: bool>(
 ) {
     let view_lights = view.into_inner();
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+    let time_span = diagnostics.time_span(ctx.command_encoder(), "per_view_shadow_pass");
+
     for view_light_entity in view_lights.lights.iter().copied() {
         let Ok((
             view_light,
@@ -2982,6 +2987,8 @@ pub fn per_view_shadow_pass<const IS_LATE: bool>(
             &mut ctx,
         );
     }
+
+    time_span.end(ctx.command_encoder());
 }
 
 /// A common helper function to render a shadow map.

--- a/crates/bevy_pbr/src/render/mesh.wesl
+++ b/crates/bevy_pbr/src/render/mesh.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_bindings::mesh,
     mesh_functions,
     skinning,
@@ -16,9 +16,9 @@ fn morph_vertex(vertex_in: UncompressedVertex, instance_index: u32) -> Uncompres
     let vertex_index = vertex.index - first_vertex;
     let morph_descriptor_index = mesh[instance_index].morph_descriptor_index;
 
-    let weight_count = bevy_pbr::render::morph::layer_count(morph_descriptor_index);
+    let weight_count = package::render::morph::layer_count(morph_descriptor_index);
     for (var i: u32 = 0u; i < weight_count; i ++) {
-        let weight = bevy_pbr::render::morph::weight_at(i, morph_descriptor_index);
+        let weight = package::render::morph::weight_at(i, morph_descriptor_index);
         if weight == 0.0 {
             continue;
         }

--- a/crates/bevy_pbr/src/render/mesh_bindings.wesl
+++ b/crates/bevy_pbr/src/render/mesh_bindings.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::mesh_types::Mesh;
+import package::render::mesh_types::Mesh;
 import bevy_render::mesh::metadata_types::MeshMetadata;
 
 @if(!MESHLET_MESH_MATERIAL_PASS && PER_OBJECT_BUFFER_BATCH_SIZE)

--- a/crates/bevy_pbr/src/render/mesh_functions.wesl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_bindings::{
         view,
         visibility_ranges,

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wesl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wesl
@@ -17,14 +17,14 @@
 import bevy_render::occlusion_culling::mesh_preprocess_types::{
     IndirectParametersMetadata, MeshInput, PreviousMeshInput, PreprocessWorkItem
 };
-import bevy_pbr::render::mesh_types::{
+import package::render::mesh_types::{
     Mesh, MESH_FLAGS_AABB_BASED_VISIBILITY_RANGE_BIT, MESH_FLAGS_NO_FRUSTUM_CULLING_BIT,
     MESH_FLAGS_VISIBILITY_RANGE_INDEX_BITS
 };
-import bevy_pbr::render::mesh_view_bindings::view;
-import bevy_pbr::render::occlusion_culling;
-import bevy_pbr::prepass::bindings::previous_view_uniforms;
-import bevy_pbr::render::view_transformations::{
+import package::render::mesh_view_bindings::view;
+import package::render::occlusion_culling;
+import package::prepass::bindings::previous_view_uniforms;
+import package::render::view_transformations::{
     position_world_to_ndc, position_world_to_view, ndc_to_uv, view_z_to_depth_ndc,
     position_world_to_prev_ndc, position_world_to_prev_view, prev_view_z_to_depth_ndc
 };

--- a/crates/bevy_pbr/src/render/mesh_types.wesl
+++ b/crates/bevy_pbr/src/render/mesh_types.wesl
@@ -7,7 +7,7 @@ struct Mesh {
     // [0].xyz, [1].x,
     // [1].yz, [2].xy
     // [2].z
-    // Use bevy_pbr::render::mesh_functions::mat2x4_f32_to_mat3x3_unpack to unpack
+    // Use package::render::mesh_functions::mat2x4_f32_to_mat3x3_unpack to unpack
     local_from_world_transpose_a: mat2x4<f32>,
     local_from_world_transpose_b: f32,
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wesl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wesl
@@ -1,5 +1,5 @@
-import bevy_pbr::render::mesh_view_types as types;
-import bevy_pbr::atmosphere::types as atmosphere_types;
+import package::render::mesh_view_types as types;
+import package::atmosphere::types as atmosphere_types;
 import bevy_render::{
     view::View,
     globals::Globals,

--- a/crates/bevy_pbr/src/render/mesh_view_types.wesl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wesl
@@ -185,7 +185,7 @@ struct LightProbes {
 // Settings for screen space reflections.
 //
 // For more information on these settings, see the documentation for
-// `bevy_pbr::ssr::ScreenSpaceReflections`.
+// `package::ssr::ScreenSpaceReflections`.
 struct ScreenSpaceReflectionsSettings {
     min_perceptual_roughness: f32,
     min_perceptual_roughness_fully_active: f32,

--- a/crates/bevy_pbr/src/render/morph.wesl
+++ b/crates/bevy_pbr/src/render/morph.wesl
@@ -1,4 +1,4 @@
-@if(MORPH_TARGETS) import bevy_pbr::render::mesh_types::{MorphAttributes, MorphDescriptor, MorphWeights};
+@if(MORPH_TARGETS) import package::render::mesh_types::{MorphAttributes, MorphDescriptor, MorphWeights};
 
 @if(MORPH_TARGETS && SKINS_USE_UNIFORM_BUFFERS) {
 @group(2) @binding(2) var<uniform> morph_weights: MorphWeights;

--- a/crates/bevy_pbr/src/render/parallax_mapping.wesl
+++ b/crates/bevy_pbr/src/render/parallax_mapping.wesl
@@ -1,12 +1,12 @@
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
-import bevy_pbr::render::{
+import package::render::{
     pbr_bindings::{depth_map_texture, depth_map_sampler},
     mesh_bindings::mesh
 };
 
 @if(BINDLESS)
-import bevy_pbr::render::pbr_bindings::material_indices;
+import package::render::pbr_bindings::material_indices;
 
 fn sample_depth_map(uv: vec2<f32>, material_bind_group_slot: u32) -> f32 {
     // We use `textureSampleLevel` over `textureSample` because the wgpu DX12

--- a/crates/bevy_pbr/src/render/pbr.wesl
+++ b/crates/bevy_pbr/src/render/pbr.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_types,
         pbr_functions::alpha_discard,
@@ -8,28 +8,28 @@ import bevy_pbr::{
 };
 
 @if(PREPASS_PIPELINE)
-import bevy_pbr::{
+import package::{
     prepass::io::{VertexOutput, FragmentOutput},
     deferred::functions::deferred_output,
 };
 @else
-import bevy_pbr::render::{
+import package::render::{
     forward_io::{VertexOutput, FragmentOutput},
     pbr_functions::{apply_pbr_lighting, main_pass_post_lighting_processing},
     pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT,
 };
 
 @if(VISIBILITY_RANGE_DITHER)
-import bevy_pbr::render::pbr_functions::visibility_range_dither;
+import package::render::pbr_functions::visibility_range_dither;
 
 @if(MESHLET_MESH_MATERIAL_PASS)
-import bevy_pbr::meshlet::visibility_buffer_resolve::resolve_vertex_output;
+import package::meshlet::visibility_buffer_resolve::resolve_vertex_output;
 
 @if(MATERIAL_OIT_ENABLED)
 import bevy_core_pipeline::oit::draw::oit_draw;
 
 @if(FORWARD_DECAL)
-import bevy_pbr::decal::forward::get_forward_decal_info;
+import package::decal::forward::get_forward_decal_info;
 
 @fragment
 fn fragment(

--- a/crates/bevy_pbr/src/render/pbr_ambient.wesl
+++ b/crates/bevy_pbr/src/render/pbr_ambient.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     pbr_lighting::{EnvBRDFApprox, F_AB},
     mesh_view_bindings::lights,
 };

--- a/crates/bevy_pbr/src/render/pbr_bindings.wesl
+++ b/crates/bevy_pbr/src/render/pbr_bindings.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::pbr_types::StandardMaterial;
+import package::render::pbr_types::StandardMaterial;
 
 @if(BINDLESS) {
 struct StandardMaterialBindings {

--- a/crates/bevy_pbr/src/render/pbr_fragment.wesl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wesl
@@ -1,6 +1,6 @@
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
-import bevy_pbr::{
+import package::{
     render::{
         pbr_functions,
         pbr_functions::SampleBias,
@@ -16,19 +16,19 @@ import bevy_pbr::{
 };
 
 @if(SCREEN_SPACE_AMBIENT_OCCLUSION)
-import bevy_pbr::render::mesh_view_bindings::screen_space_ambient_occlusion_texture;
+import package::render::mesh_view_bindings::screen_space_ambient_occlusion_texture;
 @if(SCREEN_SPACE_AMBIENT_OCCLUSION)
-import bevy_pbr::ssao::utils::ssao_multibounce;
+import package::ssao::utils::ssao_multibounce;
 
 @if(MESHLET_MESH_MATERIAL_PASS)
-import bevy_pbr::meshlet::visibility_buffer_resolve::VertexOutput;
+import package::meshlet::visibility_buffer_resolve::VertexOutput;
 @elif(PREPASS_PIPELINE)
-import bevy_pbr::prepass::io::VertexOutput;
+import package::prepass::io::VertexOutput;
 @else
-import bevy_pbr::render::forward_io::VertexOutput;
+import package::render::forward_io::VertexOutput;
 
 @if(BINDLESS)
-import bevy_pbr::render::pbr_bindings::material_indices;
+import package::render::pbr_bindings::material_indices;
 
 // prepare a basic PbrInput from the vertex stage output, mesh binding and view binding
 fn pbr_input_from_vertex_output(

--- a/crates/bevy_pbr/src/render/pbr_fragment.wesl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wesl
@@ -528,7 +528,8 @@ pbr_input.material.uv_transform = uv_transform;
             diffuse_occlusion *= textureSampleBias(texture, sampler_, coords, bias.mip_bias).r;
         }
 @if(SCREEN_SPACE_AMBIENT_OCCLUSION) {
-        let ssao = textureLoad(screen_space_ambient_occlusion_texture, vec2<i32>(in.position.xy), 0i).r;
+        let ssao_tex_pos = vec2<i32>(in.position.xy - view.viewport.xy);
+        let ssao = textureLoad(screen_space_ambient_occlusion_texture, ssao_tex_pos, 0i).r;
         let ssao_multibounce = ssao_multibounce(ssao, pbr_input.material.base_color.rgb);
         diffuse_occlusion = min(diffuse_occlusion, ssao_multibounce);
         // Use SSAO to estimate the specular occlusion.

--- a/crates/bevy_pbr/src/render/pbr_functions.wesl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_types,
         pbr_bindings,
@@ -19,19 +19,19 @@ import bevy_pbr::{
     },
     ssr::raymarch,
 };
-import bevy_pbr::render::mesh_view_bindings::globals;
-import bevy_pbr::render::view_transformations::{position_world_to_ndc};
+import package::render::mesh_view_bindings::globals;
+import package::render::view_transformations::{position_world_to_ndc};
 import bevy_render::maths::{E, powsafe};
 
-@if(STANDARD_MATERIAL_SPECULAR_TRANSMISSION) import bevy_pbr::transmission;
+@if(STANDARD_MATERIAL_SPECULAR_TRANSMISSION) import package::transmission;
 
-@if(IRRADIANCE_VOLUME) import bevy_pbr::light_probe::irradiance_volume;
+@if(IRRADIANCE_VOLUME) import package::light_probe::irradiance_volume;
 
-@if(MESHLET_MESH_MATERIAL_PASS) import bevy_pbr::meshlet::visibility_buffer_resolve::VertexOutput;
-@elif(PREPASS_PIPELINE) import bevy_pbr::prepass::io::VertexOutput;
-@else import bevy_pbr::render::forward_io::VertexOutput;
+@if(MESHLET_MESH_MATERIAL_PASS) import package::meshlet::visibility_buffer_resolve::VertexOutput;
+@elif(PREPASS_PIPELINE) import package::prepass::io::VertexOutput;
+@else import package::render::forward_io::VertexOutput;
 
-@if(ENVIRONMENT_MAP) import bevy_pbr::light_probe::environment_map;
+@if(ENVIRONMENT_MAP) import package::light_probe::environment_map;
 
 @if(TONEMAP_IN_SHADER) import bevy_core_pipeline::tonemapping::{tone_mapping, screen_space_dither};
 
@@ -897,13 +897,13 @@ fn apply_fog(
     }
 
     if fog_params.mode == mesh_view_types::FOG_MODE_LINEAR {
-        return bevy_pbr::render::fog::linear_fog(fog_params, input_color, distance, scattering);
+        return package::render::fog::linear_fog(fog_params, input_color, distance, scattering);
     } else if fog_params.mode == mesh_view_types::FOG_MODE_EXPONENTIAL {
-        return bevy_pbr::render::fog::exponential_fog(fog_params, input_color, distance, scattering);
+        return package::render::fog::exponential_fog(fog_params, input_color, distance, scattering);
     } else if fog_params.mode == mesh_view_types::FOG_MODE_EXPONENTIAL_SQUARED {
-        return bevy_pbr::render::fog::exponential_squared_fog(fog_params, input_color, distance, scattering);
+        return package::render::fog::exponential_squared_fog(fog_params, input_color, distance, scattering);
     } else if fog_params.mode == mesh_view_types::FOG_MODE_ATMOSPHERIC {
-        return bevy_pbr::render::fog::atmospheric_fog(fog_params, input_color, distance, scattering);
+        return package::render::fog::atmospheric_fog(fog_params, input_color, distance, scattering);
     } else {
         return input_color;
     }

--- a/crates/bevy_pbr/src/render/pbr_lighting.wesl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wesl
@@ -296,7 +296,8 @@ fn G_Smith(NdotV: f32, NdotL: f32, roughness: f32) -> f32 {
 //
 // https://google.github.io/filament/Filament.md.html#materialsystem/clearcoatmodel
 fn V_Kelemen(LdotH: f32) -> f32 {
-    return 0.25 / (LdotH * LdotH);
+    let l_dot_h = max(LdotH, 0.0001);
+    return 0.25 / (l_dot_h * l_dot_h);
 }
 
 // Fresnel function

--- a/crates/bevy_pbr/src/render/pbr_lighting.wesl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::mesh_view_types::POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
     render::mesh_view_bindings as view_bindings,
     atmosphere::functions::{calculate_visible_sun_ratio, clamp_to_surface},

--- a/crates/bevy_pbr/src/render/pbr_prepass.wesl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_prepass_functions,
         pbr_bindings,
@@ -15,10 +15,10 @@ import bevy_pbr::{
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
 @if(MESHLET_MESH_MATERIAL_PASS)
-import bevy_pbr::meshlet::visibility_buffer_resolve::resolve_vertex_output;
+import package::meshlet::visibility_buffer_resolve::resolve_vertex_output;
 
 @if(BINDLESS)
-import bevy_pbr::render::pbr_bindings::material_indices;
+import package::render::pbr_bindings::material_indices;
 
 @if(PREPASS_FRAGMENT)
 @fragment

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wesl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wesl
@@ -1,6 +1,6 @@
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
-import bevy_pbr::{
+import package::{
     prepass::io::VertexOutput,
     prepass::bindings::previous_view_uniforms,
     render::{
@@ -12,7 +12,7 @@ import bevy_pbr::{
 };
 
 @if(BINDLESS)
-import bevy_pbr::render::pbr_bindings::material_indices;
+import package::render::pbr_bindings::material_indices;
 
 // Cutoff used for the premultiplied alpha modes BLEND, ADD, and ALPHA_TO_COVERAGE.
 const PREMULTIPLIED_ALPHA_CUTOFF = 0.05;

--- a/crates/bevy_pbr/src/render/shadow_sampling.wesl
+++ b/crates/bevy_pbr/src/render/shadow_sampling.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_bindings as view_bindings,
     utils::interleaved_gradient_noise,
     utils,

--- a/crates/bevy_pbr/src/render/shadows.wesl
+++ b/crates/bevy_pbr/src/render/shadows.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_types::POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
     mesh_view_bindings as view_bindings,
     shadow_sampling::{

--- a/crates/bevy_pbr/src/render/skinning.wesl
+++ b/crates/bevy_pbr/src/render/skinning.wesl
@@ -1,5 +1,5 @@
-import bevy_pbr::render::mesh_types::SkinnedMesh;
-import bevy_pbr::render::mesh_bindings::mesh;
+import package::render::mesh_types::SkinnedMesh;
+import package::render::mesh_bindings::mesh;
 
 @if(SKINNED && SKINS_USE_UNIFORM_BUFFERS)
 @group(2) @binding(1) var<uniform> joint_matrices: SkinnedMesh;

--- a/crates/bevy_pbr/src/render/utils.wesl
+++ b/crates/bevy_pbr/src/render/utils.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::rgb9e5;
+import package::render::rgb9e5;
 import bevy_render::maths::{PI, PI_2, orthonormalize};
 
 // Generates a random u32 in range [0, u32::MAX].

--- a/crates/bevy_pbr/src/render/view_transformations.wesl
+++ b/crates/bevy_pbr/src/render/view_transformations.wesl
@@ -1,5 +1,5 @@
-import bevy_pbr::render::mesh_view_bindings as view_bindings;
-import bevy_pbr::prepass::bindings as prepass_bindings;
+import package::render::mesh_view_bindings as view_bindings;
+import package::prepass::bindings as prepass_bindings;
 
 /// World space:
 /// +y is up

--- a/crates/bevy_pbr/src/render/wireframe.wesl
+++ b/crates/bevy_pbr/src/render/wireframe.wesl
@@ -1,10 +1,10 @@
-@if(WIREFRAME_WIDE) import bevy_pbr::render::{
+@if(WIREFRAME_WIDE) import package::render::{
     mesh_bindings::mesh,
     mesh_view_bindings::view,
     view_transformations::position_world_to_clip,
 };
 @if(WIREFRAME_WIDE) import bevy_render::maths::affine3_to_square;
-@if(!WIREFRAME_WIDE) import bevy_pbr::render::forward_io::VertexOutput;
+@if(!WIREFRAME_WIDE) import package::render::forward_io::VertexOutput;
 
 @if(WIREFRAME_WIDE) {
 struct Immediates {

--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
@@ -58,7 +58,8 @@ fn preprocess_depth(@builtin(global_invocation_id) global_id: vec3<u32>, @builti
     let pixel_coordinates1 = pixel_coordinates0 + vec2<i32>(1i, 0i);
     let pixel_coordinates2 = pixel_coordinates0 + vec2<i32>(0i, 1i);
     let pixel_coordinates3 = pixel_coordinates0 + vec2<i32>(1i, 1i);
-    let depths_uv = vec2<f32>(pixel_coordinates0) / view.viewport.zw;
+    let input_depth_size = vec2<f32>(textureDimensions(input_depth));
+    let depths_uv = (vec2<f32>(pixel_coordinates0) + view.viewport.xy) / input_depth_size;
     let depths = textureGather(input_depth, point_clamp_sampler, depths_uv, vec2<i32>(1i, 1i));
     textureStore(preprocessed_depth_mip0, pixel_coordinates0, vec4<f32>(depths.w, 0.0, 0.0, 0.0));
     textureStore(preprocessed_depth_mip0, pixel_coordinates1, vec4<f32>(depths.z, 0.0, 0.0, 0.0));

--- a/crates/bevy_pbr/src/ssao/ssao.wesl
+++ b/crates/bevy_pbr/src/ssao/ssao.wesl
@@ -75,8 +75,8 @@ fn calculate_neighboring_depth_differences(pixel_coordinates: vec2<i32>) -> f32 
     return depth_center;
 }
 
-fn load_normal_view_space(uv: vec2<f32>) -> vec3<f32> {
-    var world_normal = textureSampleLevel(normals, point_clamp_sampler, uv, 0.0).xyz;
+fn load_normal_view_space(uv_normals: vec2<f32>) -> vec3<f32> {
+    var world_normal = textureSampleLevel(normals, point_clamp_sampler, uv_normals, 0.0).xyz;
     world_normal = (world_normal * 2.0) - 1.0;
     let view_from_world = mat3x3<f32>(
         view.view_from_world[0].xyz,
@@ -144,7 +144,9 @@ fn ssao(@builtin(global_invocation_id) global_id: vec3<u32>) {
     pixel_depth += 0.00001; // Avoid depth precision issues
 
     let pixel_position = reconstruct_view_space_position(pixel_depth, uv);
-    let pixel_normal = load_normal_view_space(uv);
+    let normals_size = vec2<f32>(textureDimensions(normals));
+    let uv_normals = (vec2<f32>(pixel_coordinates) + 0.5 + view.viewport.xy) / normals_size;
+    let pixel_normal = load_normal_view_space(uv_normals);
     let view_vec = normalize(-pixel_position);
 
     let noise = load_noise(pixel_coordinates);

--- a/crates/bevy_pbr/src/ssr.wesl
+++ b/crates/bevy_pbr/src/ssr.wesl
@@ -1,7 +1,7 @@
 // A postprocessing pass that performs screen-space reflections.
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
-import bevy_pbr::{
+import package::{
     render::{
         clustered_forward,
         pbr_lighting as lighting,
@@ -42,7 +42,7 @@ import bevy_render::{
     maths::orthonormalize,
 };
 
-@if(ENVIRONMENT_MAP) import bevy_pbr::light_probe::environment_map;
+@if(ENVIRONMENT_MAP) import package::light_probe::environment_map;
 
 // The texture representing the color framebuffer.
 @group(2) @binding(0) var color_texture: texture_2d<f32>;

--- a/crates/bevy_pbr/src/ssr/raymarch.wesl
+++ b/crates/bevy_pbr/src/ssr/raymarch.wesl
@@ -14,8 +14,8 @@
 // [`raymarch.hlsl`]:
 // https://gist.github.com/h3r2tic/9c8356bdaefbe80b1a22ae0aaee192db
 
-import bevy_pbr::render::mesh_view_bindings::depth_prepass_texture;
-import bevy_pbr::render::view_transformations::{
+import package::render::mesh_view_bindings::depth_prepass_texture;
+import package::render::view_transformations::{
     direction_world_to_clip,
     ndc_to_uv,
     perspective_camera_near,

--- a/crates/bevy_pbr/src/transmission.wesl
+++ b/crates/bevy_pbr/src/transmission.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_lighting as lighting,
         utils::interleaved_gradient_noise,

--- a/crates/bevy_pbr/src/volumetric_fog/render.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/render.rs
@@ -18,6 +18,7 @@ use bevy_light::{FogVolume, VolumetricFog, VolumetricLight};
 use bevy_math::{vec4, Affine3A, Mat4, Vec3, Vec3A, Vec4};
 use bevy_mesh::{Mesh, MeshVertexBufferLayoutRef};
 use bevy_render::{
+    diagnostic::RecordDiagnostics,
     mesh::{allocator::MeshAllocator, RenderMesh, RenderMeshBufferInfo},
     render_asset::RenderAssets,
     render_resource::{
@@ -320,6 +321,10 @@ pub fn volumetric_fog(
         return;
     };
 
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+    let time_span = diagnostics.time_span(ctx.command_encoder(), "volumetric_lighting");
+
     let command_encoder = ctx.command_encoder();
     command_encoder.push_debug_group("volumetric_lighting");
 
@@ -329,6 +334,7 @@ pub fn volumetric_fog(
             .depth_stencil_views()
             .depth_only_view()
         else {
+            time_span.end(ctx.command_encoder());
             return;
         };
 
@@ -360,6 +366,7 @@ pub fn volumetric_fog(
         // This should always succeed, but if the asset was unloaded don't
         // panic.
         let Some(render_mesh) = render_meshes.get(&mesh_handle) else {
+            time_span.end(ctx.command_encoder());
             return;
         };
 
@@ -451,6 +458,7 @@ pub fn volumetric_fog(
     }
 
     ctx.command_encoder().pop_debug_group();
+    time_span.end(ctx.command_encoder());
 }
 
 impl SpecializedRenderPipeline for VolumetricFogPipeline {

--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wesl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wesl
@@ -14,30 +14,30 @@
 // [2]: http://www.alexandre-pestana.com/volumetric-lights/
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     functions::{calculate_visible_sun_ratio, clamp_to_surface},
     bruneton_functions::transmittance_lut_r_mu_to_uv,
 };
-import bevy_pbr::render::mesh_functions::{get_world_from_local, mesh_position_local_to_clip};
-import bevy_pbr::render::mesh_view_bindings::{
+import package::render::mesh_functions::{get_world_from_local, mesh_position_local_to_clip};
+import package::render::mesh_view_bindings::{
     globals, lights, view, clustered_lights,
     atmosphere, atmosphere_transmittance_texture, atmosphere_transmittance_sampler
 };
-import bevy_pbr::render::mesh_view_types::{
+import package::render::mesh_view_types::{
     DIRECTIONAL_LIGHT_FLAGS_VOLUMETRIC_BIT,
     POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT,
     POINT_LIGHT_FLAGS_VOLUMETRIC_BIT,
     POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
 };
-import bevy_pbr::render::shadow_sampling::{
+import package::render::shadow_sampling::{
     sample_shadow_map_hardware,
     sample_shadow_cubemap,
     sample_shadow_map,
     SPOT_SHADOW_TEXEL_SIZE
 };
-import bevy_pbr::render::shadows::{get_cascade_index, world_to_directional_light_local};
-import bevy_pbr::render::utils::interleaved_gradient_noise;
-import bevy_pbr::render::view_transformations::{
+import package::render::shadows::{get_cascade_index, world_to_directional_light_local};
+import package::render::utils::interleaved_gradient_noise;
+import package::render::view_transformations::{
     depth_ndc_to_view_z,
     frag_coord_to_ndc,
     position_ndc_to_view,
@@ -45,8 +45,8 @@ import bevy_pbr::render::view_transformations::{
     position_view_to_world
 };
 import bevy_render::maths::orthonormalize;
-import bevy_pbr::render::clustered_forward as clustering;
-import bevy_pbr::render::pbr_lighting::getDistanceAttenuation;
+import package::render::clustered_forward as clustering;
+import package::render::pbr_lighting::getDistanceAttenuation;
 
 // The GPU version of [`VolumetricFog`]. See the comments in
 // `volumetric_fog/mod.rs` for descriptions of the fields here.

--- a/crates/bevy_picking/src/window.rs
+++ b/crates/bevy_picking/src/window.rs
@@ -11,8 +11,6 @@
 //!
 //! - This backend does not provide `normal` in `HitData`.
 
-use core::f32;
-
 use bevy_camera::NormalizedRenderTarget;
 use bevy_ecs::prelude::*;
 

--- a/crates/bevy_platform/src/collections/aligned_vec.rs
+++ b/crates/bevy_platform/src/collections/aligned_vec.rs
@@ -1,4 +1,4 @@
-//! Provides [`AlignedVec`] based on [bevy_platform::collections::AlignedVec](https://github.com/rkyv/rkyv/blob/main/rkyv/src/util/alloc/aligned_vec.rs)'s implementation but the alignment can be set at runtime.
+//! Provides [`AlignedVec`] based on [rkyv::util::AlignedVec](https://github.com/rkyv/rkyv/blob/main/rkyv/src/util/alloc/aligned_vec.rs)'s implementation but the alignment can be set at runtime.
 //!
 //! The original source code, adapted here, is copyright 2021 David Koloski, used here under the MIT License.
 #![expect(unsafe_code, reason = "This struct needs to interact with raw memory")]

--- a/crates/bevy_platform/src/collections/aligned_vec.rs
+++ b/crates/bevy_platform/src/collections/aligned_vec.rs
@@ -185,7 +185,7 @@ impl AlignedVec {
     ///
     /// Usually the safe methods `reserve` or `reserve_exact` are a better
     /// choice. This method only exists as a micro-optimization for very
-    /// performance-sensitive code where where the calculation of capacity
+    /// performance-sensitive code where the calculation of capacity
     /// required has already been performed, and you want to avoid doing it
     /// again, or if you want to implement a different growth strategy.
     ///
@@ -449,7 +449,7 @@ impl AlignedVec {
     ///
     /// Usually the safe methods `reserve` or `reserve_exact` are a better
     /// choice. This method only exists as a micro-optimization for very
-    /// performance-sensitive code where where the calculation of capacity
+    /// performance-sensitive code where the calculation of capacity
     /// required has already been performed, and you want to avoid doing it
     /// again.
     ///
@@ -875,19 +875,19 @@ impl AlignedVec {
     /// This is highly unsafe, due to the number of invariants that aren't
     /// checked:
     ///
-    /// * If the capacity is nonzero, `ptr` must have
-    ///   been allocated using the global allocator, such as via the [`alloc::alloc`]
-    ///   function. If the capacity is zero, `ptr` need only be aligned.
-    /// * `align` needs to be equal to the alignment as what `ptr` was allocated with,
-    ///   if the pointer is required to be allocated.
-    /// * The `capacity` (i.e. the allocated size in bytes), if
-    ///   nonzero, needs to be the same size as the pointer was allocated with.
-    ///   (Because similar to alignment, [`dealloc`] must be called with the same
-    ///   layout `size`.)
+    /// * `align` must be a non-zero power of two, and must be less than
+    ///   `isize::MAX`.
+    /// * `capacity`, when rounded up to the nearest multiple of `align`, must
+    ///   not overflow `isize`.
+    /// * If the capacity is nonzero, `ptr` must have been allocated using
+    ///   the global allocator, such as via the [`alloc::alloc`] function,
+    ///   with a [`Layout`] using this exact `align` and a `size` of `capacity`.
+    ///   (Because similar to alignment, [`dealloc`] must be called with the
+    ///   same layout `size`.)
+    /// * If the capacity is zero, `ptr` need not point to allocated memory,
+    ///   but it must still be aligned to `align` bytes (i.e.
+    ///   `ptr.as_ptr() as usize % align == 0`).
     /// * `length` needs to be less than or equal to `capacity`.
-    /// * `capacity` needs to be the capacity that the pointer was allocated with,
-    ///   if the pointer is required to be allocated.
-    /// * The allocated size in bytes must be no larger than `isize::MAX`.
     ///
     /// # Example
     ///

--- a/crates/bevy_post_process/src/dof/dof.wesl
+++ b/crates/bevy_post_process/src/dof/dof.wesl
@@ -18,7 +18,7 @@
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
 import bevy_pbr::render::mesh_view_bindings::view;
 import bevy_pbr::render::view_transformations::depth_ndc_to_view_z;
-import bevy_post_process::gaussian_blur::gaussian_blur;
+import package::gaussian_blur::gaussian_blur;
 import bevy_render::view::View;
 
 // Parameters that control the depth of field effect. See

--- a/crates/bevy_post_process/src/dof/mod.rs
+++ b/crates/bevy_post_process/src/dof/mod.rs
@@ -31,6 +31,7 @@ use bevy_math::ops;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::{
     camera::ExtractedCamera,
+    diagnostic::RecordDiagnostics,
     extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
     render_resource::{
         binding_types::{
@@ -791,6 +792,10 @@ pub(crate) fn depth_of_field(
     else {
         return;
     };
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+    let time_span = diagnostics.time_span(ctx.command_encoder(), "depth_of_field");
+
     // We can be in either Gaussian blur or bokeh mode here. Both modes are
     // similar, consisting of two passes each.
     for pipeline_render_info in view_pipelines.pipeline_render_info().iter() {
@@ -799,6 +804,7 @@ pub(crate) fn depth_of_field(
             view_uniforms.uniforms.binding(),
             &**global_bind_group,
         ) else {
+            time_span.end(ctx.command_encoder());
             return;
         };
 
@@ -896,4 +902,5 @@ pub(crate) fn depth_of_field(
         // Render the full-screen pass.
         render_pass.draw(0..3, 0..1);
     }
+    time_span.end(ctx.command_encoder());
 }

--- a/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wesl
+++ b/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wesl
@@ -2,7 +2,7 @@
 //
 // This makes edges of objects turn into multicolored streaks.
 
-// See `bevy_post_process::effect_stack::ChromaticAberration` for more
+// See `package::effect_stack::ChromaticAberration` for more
 // information on these fields.
 struct ChromaticAberrationSettings {
     intensity: f32,

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wesl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wesl
@@ -1,6 +1,6 @@
 // The lens distortion postprocessing effect.
 
-// See `bevy_post_process::effect_stack::LensDistortion` for more
+// See `package::effect_stack::LensDistortion` for more
 // information on these fields.
 struct LensDistortionSettings {
     intensity: f32,

--- a/crates/bevy_post_process/src/effect_stack/post_process.wesl
+++ b/crates/bevy_post_process/src/effect_stack/post_process.wesl
@@ -1,9 +1,9 @@
 // Miscellaneous postprocessing effects, currently just chromatic aberration.
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
-import bevy_post_process::effect_stack::chromatic_aberration::chromatic_aberration;
-import bevy_post_process::effect_stack::lens_distortion::lens_distortion;
-import bevy_post_process::effect_stack::vignette::vignette;
+import package::effect_stack::chromatic_aberration::chromatic_aberration;
+import package::effect_stack::lens_distortion::lens_distortion;
+import package::effect_stack::vignette::vignette;
 
 @fragment
 fn fragment_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {

--- a/crates/bevy_post_process/src/effect_stack/vignette.wesl
+++ b/crates/bevy_post_process/src/effect_stack/vignette.wesl
@@ -1,8 +1,8 @@
 // The vignette postprocessing effect.
 
-import bevy_post_process::effect_stack::chromatic_aberration::source_texture;
+import package::effect_stack::chromatic_aberration::source_texture;
 
-// See `bevy_post_process::effect_stack::Vignette` for more
+// See `package::effect_stack::Vignette` for more
 // information on these fields.
 struct VignetteSettings {
     intensity: f32,

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -575,6 +575,7 @@ impl<'a, T, A: IsAligned> MovingPtr<'a, T, A> {
     /// # Safety
     ///  - `dst` must be valid for writes.
     ///  - If the `A` type parameter is [`Aligned`] then `dst` must be [properly aligned] for `T`.
+    ///  - The `dst` and the pointer `self` contains must not point at the same memory address.
     ///
     /// [properly aligned]: https://doc.rust-lang.org/std/ptr/index.html#alignment
     #[inline]
@@ -586,6 +587,7 @@ impl<'a, T, A: IsAligned> MovingPtr<'a, T, A> {
         //  - The caller is required to ensure that `dst` must be valid for writes.
         //  - As `A` is `Aligned`, the caller is required to ensure that `dst` is aligned and `src` must
         //    be aligned by the type's invariants.
+        //  - The caller is required to ensure that `dst` and `src` do not point to the same memory address.
         //  - We took self by move and forgotten it, so nothing else can observe `src` being moved out.
         unsafe { A::copy_nonoverlapping(src, dst, 1) };
     }

--- a/crates/bevy_render/src/color_operations.wesl
+++ b/crates/bevy_render/src/color_operations.wesl
@@ -1,4 +1,4 @@
-import bevy_render::maths::{PI_2,PI,FRAC_PI_3};
+import package::maths::{PI_2,PI,FRAC_PI_3};
 
 const HUE_GUARD: f32 = 0.0001;
 

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -714,6 +714,7 @@ impl PipelineCache {
                 // Retry
                 ShaderCacheError::ShaderNotLoaded(_)
                 | ShaderCacheError::ShaderImportNotYetAvailable => {
+                    bevy_log::debug!("retry processing pipeline {id}: {err}");
                     cached_pipeline.state = CachedPipelineState::Queued;
                 }
 

--- a/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
@@ -8,13 +8,12 @@ use core::{
 };
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{embedded_asset, load_embedded_asset, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     resource::Resource,
     schedule::IntoScheduleConfigs as _,
-    system::{Res, ResMut},
-    world::{FromWorld, World},
+    system::{Commands, Res, ResMut},
 };
 use bevy_log::{debug, error, info};
 use bevy_material::{
@@ -32,12 +31,13 @@ use wgpu::{BufferDescriptor, BufferUsages, ComputePassDescriptor, ShaderStages};
 
 use crate::{
     diagnostic::RecordDiagnostics as _,
+    init_gpu_resource,
     render_resource::{
         AtomicPod, BindGroup, BindGroupEntries, Buffer, PipelineCache, RawBufferVec,
         SpecializedComputePipeline, SpecializedComputePipelines, UniformBuffer,
     },
     renderer::{RenderContext, RenderDevice, RenderGraph, RenderGraphSystems, RenderQueue},
-    ExtractSchedule, RenderApp,
+    ExtractSchedule, GpuResourceAppExt, RenderApp, RenderStartup,
 };
 
 /// A plugin that allows sparse updates of GPU buffers if only a small number of
@@ -55,11 +55,17 @@ impl Plugin for SparseBufferPlugin {
         };
 
         render_app
-            .init_resource::<SparseBufferUpdateJobs>()
-            .init_resource::<SparseBufferUpdatePipelines>()
-            .init_resource::<SpecializedComputePipelines<SparseBufferUpdatePipelines>>()
-            .init_resource::<SparseBufferUpdateBindGroups>()
+            .init_gpu_resource::<SparseBufferUpdateJobs>()
+            .init_gpu_resource::<SpecializedComputePipelines<SparseBufferUpdatePipelines>>()
             .add_systems(ExtractSchedule, clear_sparse_buffer_jobs)
+            .add_systems(
+                RenderStartup,
+                (
+                    init_sparse_buffer_update_pipelines,
+                    init_sparse_buffer_update_bind_groups.after(init_gpu_resource::<SpecializedComputePipelines<SparseBufferUpdatePipelines>>),
+                )
+                    .chain(),
+            )
             .add_systems(
                 RenderGraph,
                 // We perform sparse buffer updates very early so that sparse
@@ -131,7 +137,7 @@ pub struct SparseBufferUpdateBindGroups {
     /// the bind group for that buffer goes away as well.
     bind_groups: WeakKeyHashMap<Weak<SparseBufferId>, SparseBufferUpdateBindGroup>,
     /// The ID of the update shader pipeline shared among all sparse buffers.
-    pipeline_id: CachedComputePipelineId,
+    pipeline_id: Option<CachedComputePipelineId>,
 }
 
 /// A single bind group for the sparse buffer update shader.
@@ -196,9 +202,10 @@ pub fn update_sparse_buffers(
         return;
     }
 
-    let Some(compute_pipeline) =
-        pipeline_cache.get_compute_pipeline(sparse_buffer_update_bind_groups.pipeline_id)
-    else {
+    let Some(pipeline_id) = sparse_buffer_update_bind_groups.pipeline_id else {
+        return;
+    };
+    let Some(compute_pipeline) = pipeline_cache.get_compute_pipeline(pipeline_id) else {
         return;
     };
 
@@ -244,56 +251,59 @@ fn clear_sparse_buffer_jobs(mut sparse_buffer_update_jobs: ResMut<SparseBufferUp
     sparse_buffer_update_jobs.clear();
 }
 
-impl FromWorld for SparseBufferUpdatePipelines {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.resource::<RenderDevice>();
-        let limit = render_device.limits().max_storage_buffers_per_shader_stage;
-
-        if limit < 3 {
-            info!(
-                "Sparse buffer updates disabled. RenderDevice lacks support: max_storage_buffers_per_shader_stage ({}) < 3.",
-                limit
-            );
-
-            return SparseBufferUpdatePipelines {
-                bind_group_layout: None,
-                shader: None,
-            };
-        }
-
-        let bind_group_layout = BindGroupLayoutDescriptor::new(
-            "sparse buffer update bind group layout",
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::COMPUTE,
-                (
-                    // @group(0) @binding(0) var<storage, read_write> dest_buffer: array<u32>;
-                    storage_buffer::<u32>(false),
-                    // @group(0) @binding(1) var<storage> src_buffer: array<u32>;
-                    storage_buffer_read_only::<u32>(false),
-                    // @group(0) @binding(2) var<storage> indices: array<u32>;
-                    storage_buffer_read_only::<u32>(false),
-                    // @group(0) @binding(3) var<uniform> metadata:
-                    // SparseBufferUpdateMetadata;
-                    uniform_buffer::<GpuSparseBufferUpdateMetadata>(false),
-                ),
-            ),
+pub fn init_sparse_buffer_update_pipelines(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    render_device: Res<RenderDevice>,
+) {
+    let limit = render_device.limits().max_storage_buffers_per_shader_stage;
+    if limit < 3 {
+        info!(
+            "Sparse buffer updates disabled. RenderDevice lacks support: max_storage_buffers_per_shader_stage ({}) < 3.",
+            limit
         );
-
-        SparseBufferUpdatePipelines {
-            bind_group_layout: Some(bind_group_layout),
-            shader: Some(load_embedded_asset!(world, "sparse_buffer_update.wesl")),
-        }
+        commands.insert_resource(SparseBufferUpdatePipelines {
+            bind_group_layout: None,
+            shader: None,
+        });
+        return;
     }
+
+    let bind_group_layout = BindGroupLayoutDescriptor::new(
+        "sparse buffer update bind group layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::COMPUTE,
+            (
+                // @group(0) @binding(0) var<storage, read_write> dest_buffer: array<u32>;
+                storage_buffer::<u32>(false),
+                // @group(0) @binding(1) var<storage> src_buffer: array<u32>;
+                storage_buffer_read_only::<u32>(false),
+                // @group(0) @binding(2) var<storage> indices: array<u32>;
+                storage_buffer_read_only::<u32>(false),
+                // @group(0) @binding(3) var<uniform> metadata:
+                // SparseBufferUpdateMetadata;
+                uniform_buffer::<GpuSparseBufferUpdateMetadata>(false),
+            ),
+        ),
+    );
+
+    commands.insert_resource(SparseBufferUpdatePipelines {
+        bind_group_layout: Some(bind_group_layout),
+        shader: Some(load_embedded_asset!(
+            asset_server.as_ref(),
+            "sparse_buffer_update.wesl"
+        )),
+    });
 }
 
 impl SpecializedComputePipeline for SparseBufferUpdatePipelines {
-    type Key = ();
+    type Key = Handle<Shader>;
 
-    fn specialize(&self, _: Self::Key) -> ComputePipelineDescriptor {
+    fn specialize(&self, key: Self::Key) -> ComputePipelineDescriptor {
         ComputePipelineDescriptor {
             label: Some("sparse buffer update pipeline".into()),
             layout: self.bind_group_layout.clone().into_iter().collect(),
-            shader: self.shader.clone().unwrap_or_default(),
+            shader: key,
             shader_defs: vec![],
             ..ComputePipelineDescriptor::default()
         }
@@ -768,26 +778,26 @@ where
     }
 }
 
-impl FromWorld for SparseBufferUpdateBindGroups {
-    fn from_world(world: &mut World) -> Self {
-        world.resource_scope::<SpecializedComputePipelines<SparseBufferUpdatePipelines>, _>(
-            |world, mut specialized_sparse_buffer_update_pipelines| {
-                let pipeline_cache = world.resource::<PipelineCache>();
-                let sparse_buffer_update_pipelines =
-                    world.resource::<SparseBufferUpdatePipelines>();
-                let pipeline_id = specialized_sparse_buffer_update_pipelines.specialize(
-                    pipeline_cache,
-                    sparse_buffer_update_pipelines,
-                    (),
-                );
-
-                SparseBufferUpdateBindGroups {
-                    bind_groups: WeakKeyHashMap::default(),
-                    pipeline_id,
-                }
-            },
+pub fn init_sparse_buffer_update_bind_groups(
+    mut commands: Commands,
+    mut specialized_sparse_buffer_update_pipelines: ResMut<
+        SpecializedComputePipelines<SparseBufferUpdatePipelines>,
+    >,
+    pipeline_cache: Res<PipelineCache>,
+    sparse_buffer_update_pipelines: Res<SparseBufferUpdatePipelines>,
+) {
+    let pipeline_id = sparse_buffer_update_pipelines.shader.clone().map(|shader| {
+        specialized_sparse_buffer_update_pipelines.specialize(
+            &pipeline_cache,
+            &sparse_buffer_update_pipelines,
+            shader,
         )
-    }
+    });
+
+    commands.insert_resource(SparseBufferUpdateBindGroups {
+        bind_groups: WeakKeyHashMap::default(),
+        pipeline_id,
+    });
 }
 
 /// Marks elements within the range `old_len..new_len` as dirty, under the

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -270,8 +270,10 @@ impl RenderVisibleEntitiesClass {
     /// no-CPU-culling visible entries table.
     pub fn entity_pair_is_visible(&self, entity: Entity, main_entity: MainEntity) -> bool {
         self.entities_cpu_culling
-            .binary_search(&(entity, main_entity))
-            .is_ok()
+            // We need to search by the same key used to sort the vec
+            // in `collect_visible_cpu_culled_entities_for_subview()`
+            .binary_search_by_key(&main_entity, |(_, main_entity)| *main_entity)
+            .is_ok_and(|index| self.entities_cpu_culling[index].0 == entity)
             || self
                 .entities_gpu_culling
                 .get(&main_entity)
@@ -425,5 +427,60 @@ fn collect_visible_cpu_culled_entities_for_subview(
             .sort_unstable_by_key(|(_, main_entity)| *main_entity);
 
         entities.update_cpu_culled_entities(&render_view_entities.entities);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_visible_entity_pair_lookup_uses_main_entity_sort_order() {
+        struct TestVisibilityClass;
+
+        let main_a = MainEntity::from(Entity::from_bits(1));
+        let main_b = MainEntity::from(Entity::from_bits(2));
+
+        // We need the render entities to sort differently from the main entities
+        let render_a = Entity::from_bits(2);
+        let render_b = Entity::from_bits(1);
+
+        let mut pairs = vec![(render_a, main_a), (render_b, main_b)];
+
+        let mut extracted = RenderExtractedVisibleEntities {
+            classes: TypeIdHashMap::from_iter([(
+                TypeId::of::<TestVisibilityClass>(),
+                RenderExtractedVisibleEntitiesClass {
+                    entities: pairs.clone(),
+                },
+            )]),
+        };
+        let mut render_visible_entities = RenderVisibleEntities::default();
+
+        collect_visible_cpu_culled_entities_for_subview(
+            &mut render_visible_entities,
+            &mut Some(&mut extracted),
+            &mut HashSet::default(),
+        );
+
+        let visible = render_visible_entities
+            .get::<TestVisibilityClass>()
+            .unwrap();
+
+        // Sort the pairs by the full tuple and confirm that the sort for visible entities is
+        // different
+        pairs.sort();
+        assert_ne!(visible.entities_cpu_culling, pairs);
+        // Sort the pairs by only the main_entity to make sure the order is as expected
+        pairs.sort_by_key(|(_, main_entity)| *main_entity);
+        assert_eq!(visible.entities_cpu_culling, pairs);
+
+        // Make sure the visibility lookup works
+        for (entity, main_entity) in &pairs {
+            assert!(
+                visible.entity_pair_is_visible(*entity, *main_entity),
+                "expected {entity:?}/{main_entity:?} to be visible"
+            );
+        }
     }
 }

--- a/crates/bevy_solari/src/pathtracer/pathtracer.wesl
+++ b/crates/bevy_solari/src/pathtracer/pathtracer.wesl
@@ -1,9 +1,9 @@
 import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance;
 import bevy_pbr::render::utils::{rand_f, rand_vec2f};
 import bevy_render::view::View;
-import bevy_solari::scene::brdf::{evaluate_brdf, evaluate_and_sample_brdf, brdf_pdf, F_AB};
-import bevy_solari::scene::sampling::{sample_random_light, random_emissive_light_pdf, power_heuristic};
-import bevy_solari::scene::bindings::{trace_ray, resolve_ray_hit_full, RAY_T_MIN, RAY_T_MAX, MIRROR_ROUGHNESS_THRESHOLD};
+import package::scene::brdf::{evaluate_brdf, evaluate_and_sample_brdf, brdf_pdf, F_AB};
+import package::scene::sampling::{sample_random_light, random_emissive_light_pdf, power_heuristic};
+import package::scene::bindings::{trace_ray, resolve_ray_hit_full, RAY_T_MIN, RAY_T_MAX, MIRROR_ROUGHNESS_THRESHOLD};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/bindings.wesl
+++ b/crates/bevy_solari/src/realtime/bindings.wesl
@@ -1,6 +1,6 @@
 import bevy_render::view::View;
 import bevy_pbr::prepass::bindings::PreviousViewUniforms;
-import bevy_solari::scene::sampling::{LightSample, NULL_LIGHT_ID};
+import package::scene::sampling::{LightSample, NULL_LIGHT_ID};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/gbuffer_utils.wesl
+++ b/crates/bevy_solari/src/realtime/gbuffer_utils.wesl
@@ -2,7 +2,7 @@ import bevy_pbr::deferred::types::unpack_24bit_normal;
 import bevy_pbr::render::rgb9e5::rgb9e5_to_vec3_;
 import bevy_render::utils::octahedral_decode;
 import bevy_render::view::{View, depth_ndc_to_view_z};
-import bevy_solari::scene::bindings::ResolvedMaterial;
+import package::scene::bindings::ResolvedMaterial;
 
 struct ResolvedGPixel {
     world_position: vec3<f32>,

--- a/crates/bevy_solari/src/realtime/initial_path.wesl
+++ b/crates/bevy_solari/src/realtime/initial_path.wesl
@@ -2,18 +2,18 @@ import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance;
 import bevy_pbr::render::utils::{rand_f, rand_range_u};
 import bevy_render::maths::PI;
 import bevy_render::utils::octahedral_encode;
-import bevy_solari::scene::brdf::{brdf_pdf, evaluate_and_sample_brdf, evaluate_brdf, F_AB};
-import bevy_solari::realtime::presample_light_tiles::unpack_resolved_light_sample;
-import bevy_solari::realtime::bindings::{empty_reservoir, light_tile_resolved_samples, light_tile_samples, Reservoir, constants, view};
-import bevy_solari::scene::sampling::{calculate_resolved_light_contribution, isinf, LightSample, NULL_LIGHT_ID, power_heuristic, trace_visibility};
-import bevy_solari::scene::bindings::{light_sources, MIRROR_ROUGHNESS_THRESHOLD, RAY_T_MAX, RAY_T_MIN, resolve_ray_hit_full, ResolvedMaterial, ResolvedRayHitFull, trace_ray};
-import bevy_solari::realtime::world_cache_query::{get_cell_size, query_world_cache, WORLD_CACHE_CELL_LIFETIME};
+import package::scene::brdf::{brdf_pdf, evaluate_and_sample_brdf, evaluate_brdf, F_AB};
+import package::realtime::presample_light_tiles::unpack_resolved_light_sample;
+import package::realtime::bindings::{empty_reservoir, light_tile_resolved_samples, light_tile_samples, Reservoir, constants, view};
+import package::scene::sampling::{calculate_resolved_light_contribution, isinf, LightSample, NULL_LIGHT_ID, power_heuristic, trace_visibility};
+import package::scene::bindings::{light_sources, MIRROR_ROUGHNESS_THRESHOLD, RAY_T_MAX, RAY_T_MIN, resolve_ray_hit_full, ResolvedMaterial, ResolvedRayHitFull, trace_ray};
+import package::realtime::world_cache_query::{get_cell_size, query_world_cache, WORLD_CACHE_CELL_LIFETIME};
 @if(DLSS_RR_GUIDE_BUFFERS)
 import bevy_pbr::render::pbr_functions::{calculate_diffuse_color, calculate_F0};
 @if(DLSS_RR_GUIDE_BUFFERS)
-import bevy_solari::realtime::bindings::{diffuse_albedo, normal_roughness, previous_view, specular_albedo, specular_motion_vectors};
+import package::realtime::bindings::{diffuse_albedo, normal_roughness, previous_view, specular_albedo, specular_motion_vectors};
 @if(DLSS_RR_GUIDE_BUFFERS)
-import bevy_solari::realtime::resolve_dlss_rr_textures::env_brdf_approx2;
+import package::realtime::resolve_dlss_rr_textures::env_brdf_approx2;
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/presample_light_tiles.wesl
+++ b/crates/bevy_solari/src/realtime/presample_light_tiles.wesl
@@ -2,8 +2,8 @@
 
 import bevy_pbr::render::rgb9e5::{vec3_to_rgb9e5_, rgb9e5_to_vec3_};
 import bevy_render::utils::{octahedral_encode, octahedral_decode};
-import bevy_solari::scene::sampling::{generate_random_light_sample, ResolvedLightSample};
-import bevy_solari::realtime::bindings::{light_tile_samples, light_tile_resolved_samples, view, constants, ResolvedLightSamplePacked};
+import package::scene::sampling::{generate_random_light_sample, ResolvedLightSample};
+import package::realtime::bindings::{light_tile_samples, light_tile_resolved_samples, view, constants, ResolvedLightSamplePacked};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/resolve_dlss_rr_textures.wesl
+++ b/crates/bevy_solari/src/realtime/resolve_dlss_rr_textures.wesl
@@ -1,6 +1,6 @@
 import bevy_pbr::render::pbr_functions::{calculate_diffuse_color, calculate_F0};
-import bevy_solari::realtime::gbuffer_utils::gpixel_resolve;
-import bevy_solari::realtime::bindings::{gbuffer, depth_buffer, motion_vectors, view, diffuse_albedo, specular_albedo, normal_roughness, specular_motion_vectors};
+import package::realtime::gbuffer_utils::gpixel_resolve;
+import package::realtime::bindings::{gbuffer, depth_buffer, motion_vectors, view, diffuse_albedo, specular_albedo, normal_roughness, specular_motion_vectors};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/restir.wesl
+++ b/crates/bevy_solari/src/realtime/restir.wesl
@@ -3,13 +3,13 @@
 import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance;
 import bevy_pbr::render::utils::{rand_f, rand_u, sample_disk};
 import bevy_render::utils::octahedral_decode;
-import bevy_solari::scene::brdf::{brdf_pdf, evaluate_brdf, F_AB};
-import bevy_solari::realtime::gbuffer_utils::{gpixel_resolve, permute_pixel, pixel_dissimilar};
-import bevy_solari::realtime::initial_path::{generate_initial_reservoir, InitialSamplingResult};
-import bevy_solari::realtime::bindings::{depth_buffer, empty_reservoir, gbuffer, motion_vectors, previous_depth_buffer, previous_gbuffer, previous_view, reservoirs_a, reservoirs_b, Reservoir, constants, view, view_output};
-import bevy_solari::scene::sampling::{balance_heuristic, calculate_resolved_light_contribution, isinf, isnan, LightSample, NULL_LIGHT_ID, power_heuristic, resolve_light_sample, ResolvedLightSample, trace_visibility, trace_visibility_previous_frame};
-import bevy_solari::scene::bindings::{light_sources, LIGHT_NOT_PRESENT_THIS_FRAME, previous_frame_light_id_translations, RAY_T_MAX, RAY_T_MIN, ResolvedMaterial};
-import bevy_solari::realtime::world_cache_query::{query_world_cache, WORLD_CACHE_CELL_LIFETIME};
+import package::scene::brdf::{brdf_pdf, evaluate_brdf, F_AB};
+import package::realtime::gbuffer_utils::{gpixel_resolve, permute_pixel, pixel_dissimilar};
+import package::realtime::initial_path::{generate_initial_reservoir, InitialSamplingResult};
+import package::realtime::bindings::{depth_buffer, empty_reservoir, gbuffer, motion_vectors, previous_depth_buffer, previous_gbuffer, previous_view, reservoirs_a, reservoirs_b, Reservoir, constants, view, view_output};
+import package::scene::sampling::{balance_heuristic, calculate_resolved_light_contribution, isinf, isnan, LightSample, NULL_LIGHT_ID, power_heuristic, resolve_light_sample, ResolvedLightSample, trace_visibility, trace_visibility_previous_frame};
+import package::scene::bindings::{light_sources, LIGHT_NOT_PRESENT_THIS_FRAME, previous_frame_light_id_translations, RAY_T_MAX, RAY_T_MIN, ResolvedMaterial};
+import package::realtime::world_cache_query::{query_world_cache, WORLD_CACHE_CELL_LIFETIME};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/world_cache_compact.wesl
+++ b/crates/bevy_solari/src/realtime/world_cache_compact.wesl
@@ -1,5 +1,5 @@
-import bevy_solari::realtime::world_cache_query::WORLD_CACHE_EMPTY_CELL;
-import bevy_solari::realtime::bindings::{
+import package::realtime::world_cache_query::WORLD_CACHE_EMPTY_CELL;
+import package::realtime::bindings::{
     world_cache,
 };
 

--- a/crates/bevy_solari/src/realtime/world_cache_query.wesl
+++ b/crates/bevy_solari/src/realtime/world_cache_query.wesl
@@ -1,7 +1,7 @@
 import constants::WORLD_CACHE_SIZE;
 import bevy_pbr::render::utils::{rand_f, rand_vec2f};
 import bevy_render::maths::orthonormalize;
-import bevy_solari::realtime::bindings::{
+import package::realtime::bindings::{
     world_cache,
     constants,
 };

--- a/crates/bevy_solari/src/realtime/world_cache_update.wesl
+++ b/crates/bevy_solari/src/realtime/world_cache_update.wesl
@@ -1,10 +1,10 @@
 import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance;
 import bevy_pbr::render::utils::{rand_f, rand_range_u, sample_cosine_hemisphere};
-import bevy_solari::realtime::presample_light_tiles::unpack_resolved_light_sample;
-import bevy_solari::scene::sampling::{calculate_resolved_light_contribution, trace_visibility};
-import bevy_solari::scene::bindings::{trace_ray, resolve_ray_hit_full, RAY_T_MIN};
-import bevy_solari::realtime::world_cache_query::query_world_cache;
-import bevy_solari::realtime::bindings::{
+import package::realtime::presample_light_tiles::unpack_resolved_light_sample;
+import package::scene::sampling::{calculate_resolved_light_contribution, trace_visibility};
+import package::scene::bindings::{trace_ray, resolve_ray_hit_full, RAY_T_MIN};
+import package::realtime::world_cache_query::query_world_cache;
+import package::realtime::bindings::{
     light_tile_resolved_samples,
     view,
     constants,

--- a/crates/bevy_solari/src/scene/brdf.wesl
+++ b/crates/bevy_solari/src/scene/brdf.wesl
@@ -3,8 +3,8 @@ import bevy_pbr::render::pbr_lighting::{D_GGX, V_SmithGGXCorrelated, specular_mu
 import bevy_pbr::render::pbr_functions::calculate_F0_dielectric;
 import bevy_pbr::render::utils::{rand_f, sample_cosine_hemisphere};
 import bevy_render::maths::{PI, orthonormalize};
-import bevy_solari::scene::sampling::{sample_ggx_vndf, ggx_vndf_pdf, ggx_vndf_sample_invalid};
-import bevy_solari::scene::bindings::{ResolvedMaterial, MIRROR_ROUGHNESS_THRESHOLD, brdf_dfg_lut, brdf_dfg_lut_sampler};
+import package::scene::sampling::{sample_ggx_vndf, ggx_vndf_pdf, ggx_vndf_sample_invalid};
+import package::scene::bindings::{ResolvedMaterial, MIRROR_ROUGHNESS_THRESHOLD, brdf_dfg_lut, brdf_dfg_lut_sampler};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/scene/sampling.wesl
+++ b/crates/bevy_solari/src/scene/sampling.wesl
@@ -1,7 +1,7 @@
 import bevy_pbr::render::pbr_lighting::D_GGX;
 import bevy_pbr::render::utils::{rand_vec2f, rand_u, rand_range_u};
 import bevy_render::maths::{PI_2, orthonormalize};
-import bevy_solari::scene::bindings::{trace_ray, trace_ray_previous_frame, RAY_T_MIN, RAY_T_MAX, light_sources, directional_lights, LightSource, LIGHT_SOURCE_KIND_DIRECTIONAL, resolve_triangle_data_full, ResolvedRayHitFull, MIRROR_ROUGHNESS_THRESHOLD};
+import package::scene::bindings::{trace_ray, trace_ray_previous_frame, RAY_T_MIN, RAY_T_MAX, light_sources, directional_lights, LightSource, LIGHT_SOURCE_KIND_DIRECTIONAL, resolve_triangle_data_full, ResolvedRayHitFull, MIRROR_ROUGHNESS_THRESHOLD};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -5,11 +5,10 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{component::Component, reflect::ReflectComponent, template::FromTemplate};
 use bevy_image::{Image, TextureAtlas, TextureAtlasLayout};
 use bevy_math::{Rect, UVec2, Vec2};
-use bevy_reflect::{std_traits::ReflectDefault, PartialReflect, Reflect};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::components::Transform;
 
 use crate::TextureSlicer;
-use core::hash::Hash;
 
 /// Describes a sprite to be rendered to a 2D camera
 #[derive(Component, Debug, Default, Clone, Reflect, FromTemplate)]
@@ -255,13 +254,6 @@ pub enum SpriteScalingMode {
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
 #[doc(alias = "pivot")]
 pub struct Anchor(pub Vec2);
-
-impl Eq for Anchor {}
-impl Hash for Anchor {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.0.reflect_hash().hash(state);
-    }
-}
 
 #[expect(missing_docs, reason = "the associated constants are self-documenting")]
 impl Anchor {

--- a/crates/bevy_sprite/src/sprite_mesh.rs
+++ b/crates/bevy_sprite/src/sprite_mesh.rs
@@ -4,7 +4,7 @@ use bevy_color::Color;
 use bevy_ecs::{component::Component, reflect::ReflectComponent, template::FromTemplate};
 use bevy_image::{Image, TextureAtlas, TextureAtlasLayout};
 use bevy_math::{Rect, UVec2, Vec2};
-use bevy_reflect::{std_traits::ReflectDefault, PartialReflect, Reflect};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::components::Transform;
 
 use crate::{Anchor, SpriteImageMode};
@@ -44,19 +44,6 @@ pub struct SpriteMesh {
     /// set it to `Blend` instead (significantly worse for performance).
     pub alpha_mode: SpriteAlphaMode,
 }
-
-impl core::hash::Hash for SpriteMesh {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.image.hash(state);
-        self.texture_atlas.hash(state);
-        self.color.reflect_hash().hash(state);
-        self.custom_size.reflect_hash().hash(state);
-        self.flip_x.hash(state);
-        self.flip_y.hash(state);
-    }
-}
-
-impl Eq for SpriteMesh {}
 
 // NOTE: The SpriteImageMode, SpriteScalingMode and Anchor are imported from the sprite module.
 

--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -277,7 +277,7 @@ pub fn update_text2d_layout(
                 &mut font_system,
                 &mut layout_cx,
                 logical_viewport_size,
-                rem_size.0,
+                *rem_size,
             ) {
                 Err(
                     TextError::NoSuchFont

--- a/crates/bevy_sprite_render/src/mesh2d/bindings.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/bindings.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::types::Mesh2d;
+import package::mesh2d::types::Mesh2d;
 import bevy_render::mesh::metadata_types::MeshMetadata;
 
 @if(PER_OBJECT_BUFFER_BATCH_SIZE)

--- a/crates/bevy_sprite_render/src/mesh2d/color_material.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/color_material.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::{
+import package::mesh2d::{
     vertex_output::VertexOutput,
     view_bindings::view,
     bindings::mesh,

--- a/crates/bevy_sprite_render/src/mesh2d/functions.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/functions.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::{
+import package::mesh2d::{
     view_bindings::view,
     bindings::{mesh, metadata},
 };

--- a/crates/bevy_sprite_render/src/mesh2d/mesh2d.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh2d.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::{
+import package::mesh2d::{
     functions as mesh_functions,
     vertex_output::VertexOutput,
     view_bindings::view,

--- a/crates/bevy_sprite_render/src/mesh2d/vertex_input.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/vertex_input.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::functions as mesh_functions;
+import package::mesh2d::functions as mesh_functions;
 
 struct UncompressedVertex {
     @builtin(instance_index) instance_index: u32,

--- a/crates/bevy_sprite_render/src/mesh2d/wireframe2d.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/wireframe2d.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::vertex_output::VertexOutput;
+import package::mesh2d::vertex_output::VertexOutput;
 
 struct PushConstants {
     color: vec4<f32>

--- a/crates/bevy_sprite_render/src/render/sprite.wesl
+++ b/crates/bevy_sprite_render/src/render/sprite.wesl
@@ -10,7 +10,7 @@ import bevy_render::{
     view::View,
 };
 
-import bevy_sprite_render::render::sprite_view_bindings::view;
+import package::render::sprite_view_bindings::view;
 
 struct VertexInput {
     @builtin(vertex_index) index: u32,

--- a/crates/bevy_sprite_render/src/sprite_mesh/bindings.wesl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/bindings.wesl
@@ -1,6 +1,6 @@
-import bevy_sprite_render::sprite_mesh::types::SpriteMaterial;
+import package::sprite_mesh::types::SpriteMaterial;
 @if(BINDLESS)
-import bevy_sprite_render::sprite_mesh::types::SpriteMaterialBindings;
+import package::sprite_mesh::types::SpriteMaterialBindings;
 
 @if(BINDLESS) {
 @group(constants::MATERIAL_BIND_GROUP) @binding(0) var<storage> material_indices:

--- a/crates/bevy_sprite_render/src/sprite_mesh/functions.wesl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/functions.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::sprite_mesh::{
+import package::sprite_mesh::{
     types::{
         SPRITE_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS,
         SPRITE_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE,
@@ -11,10 +11,10 @@ import bevy_sprite_render::sprite_mesh::{
     bindings::material,
 };
 @if(BINDLESS)
-import bevy_sprite_render::sprite_mesh::bindings::material_indices;
+import package::sprite_mesh::bindings::material_indices;
 @if(!BINDLESS)
-import bevy_sprite_render::sprite_mesh::bindings::{texture, texture_sampler};
-import bevy_sprite_render::mesh2d::bindings::mesh;
+import package::sprite_mesh::bindings::{texture, texture_sampler};
+import package::mesh2d::bindings::mesh;
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
 // Applies all the transformations to the UV and samples the sprite's final color.

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -1,23 +1,25 @@
 use bevy_app::{Plugin, PostUpdate};
+use bevy_color::ColorToComponents;
 use bevy_ecs::{
     entity::Entity,
+    message::MessageReader,
     query::{Added, Changed, Or},
     schedule::IntoScheduleConfigs,
     system::{Commands, Local, Query, Res, ResMut},
 };
 
-use bevy_asset::{Assets, Handle};
+use bevy_asset::{AssetEvent, AssetEventSystems, AssetId, Assets, Handle};
 
-use bevy_image::TextureAtlasLayout;
-use bevy_math::{primitives::Rectangle, vec2};
+use bevy_image::{Image, TextureAtlasLayout};
+use bevy_math::{primitives::Rectangle, vec2, FloatOrd};
 use bevy_mesh::{
     mark_2d_meshes_as_changed_if_their_assets_changed, Mesh, Mesh2d, MeshAttributeCompressionFlags,
     MeshBuilder, Meshable,
 };
 
-use bevy_platform::collections::HashMap;
+use bevy_platform::collections::{hash_map::Entry, HashMap};
 use bevy_shader::load_shader_library;
-use bevy_sprite::{prelude::SpriteMesh, Anchor};
+use bevy_sprite::{prelude::SpriteMesh, Anchor, SpriteAlphaMode};
 
 mod sprite_material;
 pub use sprite_material::*;
@@ -39,7 +41,8 @@ impl Plugin for SpriteMeshPlugin {
             (add_mesh, add_material)
                 .chain()
                 .before(check_entities_needing_specialization::<SpriteMaterial>)
-                .before(mark_2d_meshes_as_changed_if_their_assets_changed),
+                .before(mark_2d_meshes_as_changed_if_their_assets_changed)
+                .after(AssetEventSystems),
         );
     }
 }
@@ -70,44 +73,123 @@ fn add_mesh(
     }
 }
 
-// Change the material when SpriteMesh is added / changed.
-//
-// NOTE: This also adds the SpriteAtlasLayout into the SpriteMaterial,
-// but this should instead be read later, similar to the images, allowing
-// for hot reload.
+/// Key used to determine in which bucket to cache the material for a [`SpriteMesh`]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct SpriteMaterialBucketKey {
+    image: AssetId<Image>,
+    texture_atlas_layout: Option<AssetId<TextureAtlasLayout>>,
+    color: [FloatOrd; 4],
+    flip_x: bool,
+    flip_y: bool,
+    custom_size: Option<[FloatOrd; 2]>,
+    rect: Option<([FloatOrd; 2], [FloatOrd; 2])>,
+    alpha_mode: SpriteAlphaModeKey,
+    anchor: [FloatOrd; 2],
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum SpriteAlphaModeKey {
+    Opaque,
+    Mask(FloatOrd),
+    Blend,
+}
+
+impl SpriteMaterialBucketKey {
+    fn new(sprite: &SpriteMesh, anchor: &Anchor) -> Self {
+        Self {
+            image: sprite.image.id(),
+            texture_atlas_layout: sprite.texture_atlas.as_ref().map(|a| a.layout.id()),
+            color: sprite.color.to_linear().to_f32_array().map(FloatOrd),
+            flip_x: sprite.flip_x,
+            flip_y: sprite.flip_y,
+            custom_size: sprite.custom_size.map(|v| v.to_array().map(FloatOrd)),
+            rect: sprite.rect.map(|r| {
+                (
+                    r.min.to_array().map(FloatOrd),
+                    r.max.to_array().map(FloatOrd),
+                )
+            }),
+            alpha_mode: match sprite.alpha_mode {
+                SpriteAlphaMode::Opaque => SpriteAlphaModeKey::Opaque,
+                SpriteAlphaMode::Mask(mask) => SpriteAlphaModeKey::Mask(FloatOrd(mask)),
+                SpriteAlphaMode::Blend => SpriteAlphaModeKey::Blend,
+            },
+            anchor: anchor.0.to_array().map(FloatOrd),
+        }
+    }
+}
+
+/// Change the material when [`SpriteMesh`] is added / changed.
+///
+/// The materials are cached based on their [`SpriteMesh`] and [`Anchor`].
+///
+/// Since not all fields of the [`SpriteMesh`] are easy to hash, we keep multiple "buckets" keyed on
+/// parts of the struct that are easy to hash.
+///
+/// NOTE: This also adds the [`TextureAtlasLayout`] into the [`SpriteMaterial`],
+/// but this should instead be read later, similar to the images, allowing
+/// for hot reload.
 fn add_material(
+    mut commands: Commands,
     sprites: Query<
         (Entity, &SpriteMesh, &Anchor),
         Or<(Changed<SpriteMesh>, Changed<Anchor>, Added<Mesh2d>)>,
     >,
     texture_atlas_layouts: Res<Assets<TextureAtlasLayout>>,
-    mut cached_materials: Local<HashMap<(SpriteMesh, Anchor), Handle<SpriteMaterial>>>,
+    mut cached_materials: Local<
+        HashMap<SpriteMaterialBucketKey, Vec<(SpriteMesh, AssetId<SpriteMaterial>)>>,
+    >,
+    mut reversed_cached_materials: Local<HashMap<AssetId<SpriteMaterial>, SpriteMaterialBucketKey>>,
     mut materials: ResMut<Assets<SpriteMaterial>>,
-    mut commands: Commands,
+    mut material_events: MessageReader<AssetEvent<SpriteMaterial>>,
 ) {
-    for (entity, sprite, anchor) in sprites {
-        if let Some(handle) = cached_materials.get(&(sprite.clone(), *anchor)) {
-            commands
-                .entity(entity)
-                .insert(MeshMaterial2d(handle.clone()));
-        } else {
-            let mut material = SpriteMaterial::from_sprite_mesh(sprite.clone());
-            material.anchor = **anchor;
-
-            if let Some(texture_atlas) = &sprite.texture_atlas
-                && let Some(texture_atlas_layout) =
-                    texture_atlas_layouts.get(texture_atlas.layout.id())
-            {
-                material.texture_atlas_layout = Some(texture_atlas_layout.clone());
-                material.texture_atlas_index = texture_atlas.index;
+    // Remove materials from the cache
+    for event in material_events.read() {
+        if let AssetEvent::Removed { id } = event
+            && let Some(key) = reversed_cached_materials.remove(id)
+            && let Entry::Occupied(mut bucket) = cached_materials.entry(key)
+        {
+            bucket
+                .get_mut()
+                .retain(|(_, cached_material_id)| cached_material_id != id);
+            if bucket.get().is_empty() {
+                bucket.remove();
             }
-
-            let handle = materials.add(material);
-            cached_materials.insert((sprite.clone(), *anchor), handle.clone());
-
-            commands
-                .entity(entity)
-                .insert(MeshMaterial2d(handle.clone()));
         }
+    }
+
+    for (entity, sprite, anchor) in sprites {
+        // Get the bucket for the sprite and anchor
+        let bucket_key = SpriteMaterialBucketKey::new(sprite, anchor);
+        let bucket = cached_materials.entry(bucket_key).or_default();
+
+        let maybe_handle = bucket
+            .iter()
+            .find(|(cached_sprite, _)| cached_sprite == sprite)
+            .and_then(|(_, id)| materials.get_strong_handle(*id));
+
+        let handle = match maybe_handle {
+            Some(handle) => handle,
+            None => {
+                let mut material = SpriteMaterial::from_sprite_mesh(sprite.clone());
+                material.anchor = **anchor;
+
+                if let Some(texture_atlas) = &sprite.texture_atlas
+                    && let Some(texture_atlas_layout) =
+                        texture_atlas_layouts.get(texture_atlas.layout.id())
+                {
+                    material.texture_atlas_layout = Some(texture_atlas_layout.clone());
+                    material.texture_atlas_index = texture_atlas.index;
+                }
+
+                let handle = materials.add(material);
+                bucket.push((sprite.clone(), handle.id()));
+                handle
+            }
+        };
+
+        commands
+            .entity(entity)
+            .insert(MeshMaterial2d(handle.clone()));
     }
 }

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.rs
@@ -1,5 +1,3 @@
-use core::f32;
-
 use bevy_app::Plugin;
 use bevy_color::{Color, ColorToComponents};
 use bevy_image::{Image, TextureAtlas, TextureAtlasLayout};

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.wesl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::{
+import package::{
     mesh2d::functions as mesh_functions,
     mesh2d::vertex_output::VertexOutput,
     mesh2d::view_bindings::view,
@@ -8,7 +8,7 @@ import bevy_sprite_render::{
     sprite_mesh::functions as sprite_functions,
 };
 @if(BINDLESS)
-import bevy_sprite_render::sprite_mesh::bindings::material_indices;
+import package::sprite_mesh::bindings::material_indices;
 
 @if(TONEMAP_IN_SHADER)
 import bevy_core_pipeline::tonemapping;

--- a/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.wesl
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::{
+import package::mesh2d::{
     functions as mesh_functions,
     view_bindings::view,
     vertex_output::VertexOutput,

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -14,7 +14,6 @@ use parley::style::{OverflowWrap, TextWrapMode, WordBreak};
 use parley::{Alignment, AlignmentOptions, Layout, PositionedLayoutItem, StyleProperty};
 use swash::FontRef;
 
-use crate::TextBrush;
 use crate::{
     add_glyph_to_atlas,
     error::TextError,
@@ -24,6 +23,7 @@ use crate::{
     Justify, LetterSpacing, LineBreak, LineHeight, PositionedGlyph, TextBounds, TextEntity,
     TextFont, TextLayout,
 };
+use crate::{RemSize, TextBrush};
 
 struct TextSectionView<'a> {
     index: usize,
@@ -71,7 +71,7 @@ impl TextPipeline {
         font_cx: &mut FontCx,
         layout_cx: &mut LayoutCx,
         logical_viewport_size: Vec2,
-        base_rem_size: f32,
+        base_rem_size: RemSize,
     ) -> Result<(), TextError> {
         computed.entities.clear();
         computed.needs_rerender = false;
@@ -262,7 +262,7 @@ impl TextPipeline {
         font_system: &mut FontCx,
         layout_cx: &mut LayoutCx,
         logical_viewport_size: Vec2,
-        base_rem_size: f32,
+        base_rem_size: RemSize,
     ) -> Result<TextMeasureInfo, TextError> {
         const MIN_WIDTH_CONTENT_BOUNDS: TextBounds = TextBounds::new_horizontal(0.0);
 

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -759,7 +759,7 @@ impl Default for TextFont {
     fn default() -> Self {
         Self {
             font: Default::default(),
-            font_size: FontSize::from(20.),
+            font_size: FontSize::Rem(1.),
             style: FontStyle::Normal,
             weight: FontWeight::NORMAL,
             width: FontWidth::NORMAL,
@@ -802,7 +802,7 @@ impl FontSize {
         // Viewport size in logical pixels
         logical_viewport_size: Vec2,
         // Base Rem size in logical pixels
-        rem_size: f32,
+        rem_size: RemSize,
     ) -> f32 {
         match self {
             FontSize::Px(s) => s,
@@ -810,7 +810,7 @@ impl FontSize {
             FontSize::Vh(s) => logical_viewport_size.y * s / 100.,
             FontSize::VMin(s) => logical_viewport_size.min_element() * s / 100.,
             FontSize::VMax(s) => logical_viewport_size.max_element() * s / 100.,
-            FontSize::Rem(s) => rem_size * s,
+            FontSize::Rem(s) => rem_size.0 * s,
         }
     }
 }
@@ -864,13 +864,53 @@ impl From<f32> for FontSize {
     }
 }
 
-/// Base value used to resolve `Rem` units for font sizes.
-#[derive(Resource, Copy, Clone, Debug, PartialEq, Deref, DerefMut)]
+/// Default [`RemSize`] and [`EmSize`], in logical pixels
+pub const DEFAULT_REM_SIZE_PX: f32 = 20.0;
+
+/// The root font size, in logical pixels.
+///
+/// `Rem` units always resolve against this one global resource, including
+/// `FontSize::Rem`, `LetterSpacing::Rem` and `Val::Rem`.
+#[derive(Resource, Copy, Clone, Debug, PartialEq, Deref, DerefMut, Reflect)]
 pub struct RemSize(pub f32);
 
 impl Default for RemSize {
     fn default() -> Self {
-        Self(20.)
+        Self(DEFAULT_REM_SIZE_PX)
+    }
+}
+
+/// The font size, in logical pixels, used to resolve `Val::Em` values in a UI node.
+///
+/// `Em` units are relative to the font size of the node they sit on, and this is that
+/// font size made concrete. Required by `Node`, so every UI node has one.
+///
+/// If the node has a `TextFont`, the `EmSize` is derived from it whenever the `TextFont`,
+/// `RemSize` or render-target info changes; until then any value you place on it persists.
+/// If it does not have a `TextFont`, the value is yours to set, for example by an app-level
+/// propagation system. `EmSize` defaults to [`DEFAULT_REM_SIZE_PX`], which matches the default
+/// [`RemSize`] but does not track changes to it. Use `Val::Rem` instead for values that
+/// should follow the root font size.
+///
+/// Removing a `TextFont` leaves the last derived value in place.
+#[derive(Debug, PartialEq, Clone, Copy, Reflect, Component)]
+#[reflect(Default, PartialEq, Debug, Clone, Component)]
+pub struct EmSize(pub f32);
+
+impl Default for EmSize {
+    fn default() -> Self {
+        EmSize(DEFAULT_REM_SIZE_PX)
+    }
+}
+
+impl EmSize {
+    /// Resolves a [`FontSize`] to a concrete [`EmSize`] in logical pixels.
+    pub fn from_font_size(
+        font_size: FontSize,
+        logical_viewport_size: Vec2,
+        rem_size: RemSize,
+    ) -> Self {
+        EmSize(font_size.eval(logical_viewport_size, rem_size))
     }
 }
 
@@ -1337,15 +1377,18 @@ impl Default for LineHeight {
 pub enum LetterSpacing {
     /// Set letter spacing to a specific number of logical pixels
     Px(f32),
-    /// Set letter spacing to a multiple of the font size
+    /// Set letter spacing to a multiple of the root font size ([`RemSize`])
     Rem(f32),
 }
 
 impl LetterSpacing {
-    pub(crate) fn eval(self, rem_size: f32) -> f32 {
+    /// Evaluate a [`LetterSpacing`] into logical pixels either
+    /// because it specifies them directly or using the global
+    /// [`RemSize`] resource.
+    pub(crate) fn eval(self, rem_size: RemSize) -> f32 {
         match self {
             LetterSpacing::Px(px) => px,
-            LetterSpacing::Rem(rem) => rem * rem_size,
+            LetterSpacing::Rem(rem) => rem * rem_size.0,
         }
     }
 }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -37,7 +37,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.20.0-dev", default-fea
 ] }
 
 # other
-taffy = { version = "0.10", default-features = false, features = [
+taffy = { version = "0.13", default-features = false, features = [
   "std",
   "block_layout",
   "flexbox",

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1,6 +1,6 @@
 use bevy_math::{MismatchedUnitsError, StableInterpolate as _, TryStableInterpolate, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_text::FontSize;
+use bevy_text::{EmSize, FontSize, RemSize};
 use bevy_utils::default;
 use core::ops::{Div, DivAssign, Mul, MulAssign, Neg};
 use thiserror::Error;
@@ -55,6 +55,16 @@ pub enum Val {
     VMin(f32),
     /// Set this value in percent of the viewport's larger dimension.
     VMax(f32),
+    /// Set this value as a multiple of the node's own font size.
+    ///
+    /// `1em` is the node's font size, so `Val::Em(2.0)` is twice that.
+    /// Resolved from the node's [`EmSize`] component.
+    Em(f32),
+    /// Set this value as a multiple of the root font size.
+    ///
+    /// Unlike [`Val::Em`] this ignores the node's own font size, so it means the same
+    /// length anywhere in the hierarchy. Resolved from the [`RemSize`] resource.
+    Rem(f32),
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -115,6 +125,10 @@ impl core::str::FromStr for Val {
             Ok(Val::VMin(value))
         } else if unit.eq_ignore_ascii_case("vmax") {
             Ok(Val::VMax(value))
+        } else if unit.eq_ignore_ascii_case("rem") {
+            Ok(Val::Rem(value))
+        } else if unit.eq_ignore_ascii_case("em") {
+            Ok(Val::Em(value))
         } else {
             Err(ValParseError::InvalidUnit)
         }
@@ -132,32 +146,19 @@ impl PartialEq for Val {
                 | (Self::Vh(_), Self::Vh(_))
                 | (Self::VMin(_), Self::VMin(_))
                 | (Self::VMax(_), Self::VMax(_))
+                | (Self::Em(_), Self::Em(_))
+                | (Self::Rem(_), Self::Rem(_))
         );
 
-        let left = match self {
-            Self::Auto => None,
-            Self::Px(v)
-            | Self::Percent(v)
-            | Self::Vw(v)
-            | Self::Vh(v)
-            | Self::VMin(v)
-            | Self::VMax(v) => Some(v),
-        };
-
-        let right = match other {
-            Self::Auto => None,
-            Self::Px(v)
-            | Self::Percent(v)
-            | Self::Vw(v)
-            | Self::Vh(v)
-            | Self::VMin(v)
-            | Self::VMax(v) => Some(v),
-        };
+        // as long as the units are the same comparing `inner`
+        // is valid.
+        let left = self.inner();
+        let right = other.inner();
 
         match (same_unit, left, right) {
             (true, a, b) => a == b,
             // All zero-value variants are considered equal.
-            (false, Some(&a), Some(&b)) => a == 0. && b == 0.,
+            (false, Some(a), Some(b)) => a == 0. && b == 0.,
             _ => false,
         }
     }
@@ -166,6 +167,24 @@ impl PartialEq for Val {
 impl Val {
     pub const DEFAULT: Self = Self::Auto;
     pub const ZERO: Self = Self::Px(0.0);
+
+    /// Returns the number this `Val` wraps, whatever its unit, or `None` for [`Val::Auto`].
+    ///
+    /// The number is meaningless without the variant it came from — `Val::Px(4.0)` and
+    /// `Val::Rem(4.0)` both return `4.0`. Use [`Val::resolve`] for a length in pixels.
+    const fn inner(self) -> Option<f32> {
+        match self {
+            Self::Auto => None,
+            Self::Px(v)
+            | Self::Percent(v)
+            | Self::Vw(v)
+            | Self::Vh(v)
+            | Self::VMin(v)
+            | Self::VMax(v)
+            | Self::Em(v)
+            | Self::Rem(v) => Some(v),
+        }
+    }
 
     /// Returns a [`UiRect`] with its `left` equal to this value,
     /// and all other fields set to `Val::ZERO`.
@@ -323,6 +342,8 @@ impl Val {
             (Val::Vh(u), Val::Vh(v)) => Ok(Val::Vh(u + v)),
             (Val::VMin(u), Val::VMin(v)) => Ok(Val::VMin(u + v)),
             (Val::VMax(u), Val::VMax(v)) => Ok(Val::VMax(u + v)),
+            (Val::Em(u), Val::Em(v)) => Ok(Val::Em(u + v)),
+            (Val::Rem(u), Val::Rem(v)) => Ok(Val::Rem(u + v)),
             _ => Err(ValArithmeticError::IncompatibleUnits),
         }
     }
@@ -347,6 +368,8 @@ impl Val {
             (Val::Vh(u), Val::Vh(v)) => Ok(Val::Vh(u - v)),
             (Val::VMin(u), Val::VMin(v)) => Ok(Val::VMin(u - v)),
             (Val::VMax(u), Val::VMax(v)) => Ok(Val::VMax(u - v)),
+            (Val::Em(u), Val::Em(v)) => Ok(Val::Em(u - v)),
+            (Val::Rem(u), Val::Rem(v)) => Ok(Val::Rem(u - v)),
             _ => Err(ValArithmeticError::IncompatibleUnits),
         }
     }
@@ -370,6 +393,8 @@ impl Mul<f32> for Val {
             Val::Vh(value) => Val::Vh(value * rhs),
             Val::VMin(value) => Val::VMin(value * rhs),
             Val::VMax(value) => Val::VMax(value * rhs),
+            Val::Em(value) => Val::Em(value * rhs),
+            Val::Rem(value) => Val::Rem(value * rhs),
         }
     }
 }
@@ -383,7 +408,9 @@ impl MulAssign<f32> for Val {
             | Val::Vw(value)
             | Val::Vh(value)
             | Val::VMin(value)
-            | Val::VMax(value) => *value *= rhs,
+            | Val::VMax(value)
+            | Val::Em(value)
+            | Val::Rem(value) => *value *= rhs,
         }
     }
 }
@@ -400,6 +427,8 @@ impl Div<f32> for Val {
             Val::Vh(value) => Val::Vh(value / rhs),
             Val::VMin(value) => Val::VMin(value / rhs),
             Val::VMax(value) => Val::VMax(value / rhs),
+            Val::Em(value) => Val::Em(value / rhs),
+            Val::Rem(value) => Val::Rem(value / rhs),
         }
     }
 }
@@ -413,7 +442,9 @@ impl DivAssign<f32> for Val {
             | Val::Vw(value)
             | Val::Vh(value)
             | Val::VMin(value)
-            | Val::VMax(value) => *value /= rhs,
+            | Val::VMax(value)
+            | Val::Em(value)
+            | Val::Rem(value) => *value /= rhs,
         }
     }
 }
@@ -423,13 +454,15 @@ impl Neg for Val {
 
     fn neg(self) -> Self::Output {
         match self {
+            Val::Auto => Val::Auto,
             Val::Px(value) => Val::Px(-value),
             Val::Percent(value) => Val::Percent(-value),
             Val::Vw(value) => Val::Vw(-value),
             Val::Vh(value) => Val::Vh(-value),
             Val::VMin(value) => Val::VMin(-value),
             Val::VMax(value) => Val::VMax(-value),
-            _ => self,
+            Val::Em(value) => Val::Em(-value),
+            Val::Rem(value) => Val::Rem(-value),
         }
     }
 }
@@ -444,7 +477,7 @@ pub enum ValArithmeticError {
 
 impl Val {
     /// Resolves this [`Val`] to a value in physical pixels from the given `scale_factor`, `physical_base_value`,
-    /// and `physical_target_size` context values.
+    /// `physical_target_size`, `em_size`, and `rem_size` context values.
     ///
     /// Returns a [`ValArithmeticError::NonEvaluable`] if the [`Val`] is impossible to resolve into a concrete value.
     pub const fn resolve(
@@ -452,6 +485,8 @@ impl Val {
         scale_factor: f32,
         physical_base_value: f32,
         physical_target_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
     ) -> Result<f32, ValArithmeticError> {
         match self {
             Val::Percent(value) => Ok(physical_base_value * value / 100.0),
@@ -464,14 +499,21 @@ impl Val {
             Val::VMax(value) => {
                 Ok(physical_target_size.x.max(physical_target_size.y) * value / 100.0)
             }
+            Val::Em(value) => Ok(value * em_size.0 * scale_factor),
+            Val::Rem(value) => Ok(value * rem_size.0 * scale_factor),
             Val::Auto => Err(ValArithmeticError::NonEvaluable),
         }
     }
 }
 
 impl From<Val> for FontSize {
-    fn from(value: Val) -> Self {
-        match value {
+    /// Converts a [`Val`] into a [`FontSize`].
+    ///
+    /// [`Val::Em`] becomes [`FontSize::Rem`]: em is relative to the font size of the node
+    /// itself, which is the very thing being defined here, so it resolves against the root
+    /// size instead to avoid the circularity.
+    fn from(val: Val) -> Self {
+        match val {
             Val::Auto => FontSize::Rem(1.),
             Val::Px(px) => FontSize::Px(px),
             Val::Percent(percent) => FontSize::Rem(percent / 100.),
@@ -479,6 +521,8 @@ impl From<Val> for FontSize {
             Val::Vh(vh) => FontSize::Vh(vh),
             Val::VMin(vmin) => FontSize::VMin(vmin),
             Val::VMax(vmax) => FontSize::VMax(vmax),
+            Val::Rem(rem) => FontSize::Rem(rem),
+            Val::Em(em) => FontSize::Rem(em), // see comment above
         }
     }
 }
@@ -501,6 +545,8 @@ impl TryStableInterpolate for Val {
             (Val::Vh(a), Val::Vh(b)) => Ok(Val::Vh(a.interpolate_stable(b, t))),
             (Val::VMin(a), Val::VMin(b)) => Ok(Val::VMin(a.interpolate_stable(b, t))),
             (Val::VMax(a), Val::VMax(b)) => Ok(Val::VMax(a.interpolate_stable(b, t))),
+            (Val::Em(a), Val::Em(b)) => Ok(Val::Em(a.interpolate_stable(b, t))),
+            (Val::Rem(a), Val::Rem(b)) => Ok(Val::Rem(a.interpolate_stable(b, t))),
             (Val::Auto, Val::Auto) => Ok(Val::Auto),
             _ => Err(MismatchedUnitsError),
         }
@@ -540,6 +586,16 @@ pub const fn auto() -> Val {
 /// Returns a [`Val::Px`] representing a value in logical pixels.
 pub fn px<T: ValNum>(value: T) -> Val {
     Val::Px(value.val_num_f32())
+}
+
+/// Returns a [`Val::Em`] representing a value proportional to the node's own font size, represented by an [`EmSize`] component.
+pub fn em<T: ValNum>(value: T) -> Val {
+    Val::Em(value.val_num_f32())
+}
+
+/// Returns a [`Val::Rem`] representing a value proportional to the root font size.
+pub fn rem<T: ValNum>(value: T) -> Val {
+    Val::Rem(value.val_num_f32())
 }
 
 /// Returns a [`Val::Percent`] representing a percentage of the parent node's length
@@ -1136,16 +1192,30 @@ impl UiPosition {
         scale_factor: f32,
         physical_size: Vec2,
         physical_target_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
     ) -> Vec2 {
         let d = self.anchor.map(|p| if 0. < p { -1. } else { 1. });
 
         physical_size * self.anchor
             + d * Vec2::new(
                 self.x
-                    .resolve(scale_factor, physical_size.x, physical_target_size)
+                    .resolve(
+                        scale_factor,
+                        physical_size.x,
+                        physical_target_size,
+                        em_size,
+                        rem_size,
+                    )
                     .unwrap_or(0.),
                 self.y
-                    .resolve(scale_factor, physical_size.y, physical_target_size)
+                    .resolve(
+                        scale_factor,
+                        physical_size.y,
+                        physical_target_size,
+                        em_size,
+                        rem_size,
+                    )
                     .unwrap_or(0.),
             )
     }
@@ -1172,9 +1242,12 @@ impl From<(Val, Val)> for UiPosition {
 /// ```
 /// # use bevy_math::{Vec2, Vec2Swizzles};
 /// # use bevy_ui::{CornerRadius, Val};
+/// # use bevy_text::{EmSize, RemSize};
 /// let radius = Val::Px(10.0);
 /// let size = Vec2::new(100.0, 50.0);
 /// let viewport_size = Vec2::new(1920.0, 1080.0);
+/// let em_size = EmSize(20.0);
+/// let rem_size = RemSize(20.0);
 ///
 /// let c1 = CornerRadius {
 ///     x: radius,
@@ -1184,10 +1257,10 @@ impl From<(Val, Val)> for UiPosition {
 ///     x: Val::ZERO,
 ///     y: radius,
 /// };
-/// let r = c1.resolve(1.0, size, viewport_size);
+/// let r = c1.resolve(1.0, size, viewport_size, em_size, rem_size);
 /// assert_eq!(
 ///     r,
-///     c2.resolve(1.0, size, viewport_size).yx(),
+///     c2.resolve(1.0, size, viewport_size, em_size, rem_size).yx(),
 /// );
 /// assert_eq!(
 ///     r,
@@ -1234,9 +1307,12 @@ impl CornerRadius {
     /// ```
     /// # use bevy_math::Vec2;
     /// # use bevy_ui::{CornerRadius, Val};
+    /// # use bevy_text::{EmSize, RemSize};
     /// let radius = Val::Px(30.0);
     /// let size = Vec2::new(100.0, 50.0);
     /// let viewport_size = Vec2::new(1920.0, 1080.0);
+    /// let em_size = EmSize(20.0);
+    /// let rem_size = RemSize(20.0);
     ///
     /// let c1 = CornerRadius::circular(radius);
     /// let c2 = CornerRadius {
@@ -1244,10 +1320,10 @@ impl CornerRadius {
     ///     y: radius,
     /// };
     ///
-    /// let r = c1.resolve(1.0, size, viewport_size);
+    /// let r = c1.resolve(1.0, size, viewport_size, em_size, rem_size);
     /// assert_eq!(
     ///     r,
-    ///     c2.resolve(1.0, size, viewport_size),
+    ///     c2.resolve(1.0, size, viewport_size, em_size, rem_size),
     /// );
     /// assert_eq!(
     ///     r,
@@ -1269,7 +1345,14 @@ impl CornerRadius {
     }
 
     /// Resolves this corner radius into horizontal and vertical radii in physical pixels.
-    pub fn resolve(self, scale_factor: f32, size: Vec2, viewport_size: Vec2) -> Vec2 {
+    pub fn resolve(
+        self,
+        scale_factor: f32,
+        size: Vec2,
+        viewport_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
+    ) -> Vec2 {
         match self {
             Self {
                 x: Val::Auto,
@@ -1284,13 +1367,21 @@ impl CornerRadius {
                 y: radius,
             } => Vec2::splat(
                 radius
-                    .resolve(scale_factor, size.min_element(), viewport_size)
+                    .resolve(
+                        scale_factor,
+                        size.min_element(),
+                        viewport_size,
+                        em_size,
+                        rem_size,
+                    )
                     .unwrap_or(0.)
                     .clamp(0., 0.5 * size.min_element()),
             ),
             Self { x, y } => Vec2::new(
-                x.resolve(scale_factor, size.x, viewport_size).unwrap_or(0.),
-                y.resolve(scale_factor, size.y, viewport_size).unwrap_or(0.),
+                x.resolve(scale_factor, size.x, viewport_size, em_size, rem_size)
+                    .unwrap_or(0.),
+                y.resolve(scale_factor, size.y, viewport_size, em_size, rem_size)
+                    .unwrap_or(0.),
             )
             .clamp(Vec2::ZERO, 0.5 * size),
         }
@@ -1345,23 +1436,70 @@ mod tests {
     fn val_evaluate() {
         let size = 250.;
         let viewport_size = vec2(1000., 500.);
-        let result = Val::Percent(80.).resolve(1., size, viewport_size).unwrap();
+        let em_size = EmSize(10.);
+        let rem_size = RemSize(20.);
 
-        assert_eq!(result, size * 0.8);
+        assert_eq!(
+            Val::Percent(80.)
+                .resolve(1., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            size * 0.8
+        );
+        // Check em and rem
+        assert_eq!(
+            Val::Em(2.)
+                .resolve(1., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            em_size.0 * 2.
+        );
+        assert_eq!(
+            Val::Rem(5.)
+                .resolve(1., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            rem_size.0 * 5.
+        );
+        // Check scale_factor is considered
+        assert_eq!(
+            Val::Em(2.)
+                .resolve(2., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            em_size.0 * 2. * 2.
+        );
+        assert_eq!(
+            Val::Rem(5.)
+                .resolve(2., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            rem_size.0 * 5. * 2.
+        );
     }
 
     #[test]
     fn val_resolve_px() {
         let size = 250.;
         let viewport_size = vec2(1000., 500.);
-        let result = Val::Px(10.).resolve(1., size, viewport_size).unwrap();
 
+        let result = Val::Px(10.)
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
         assert_eq!(result, 10.);
 
-        let result = Val::Px(10.).resolve(3., size, viewport_size).unwrap();
+        let result = Val::Px(10.)
+            .resolve(3., size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
         assert_eq!(result, 30.);
-        let result = Val::Px(10.).resolve(0.25, size, viewport_size).unwrap();
+        let result = Val::Px(10.)
+            .resolve(0.25, size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
         assert_eq!(result, 2.5);
+
+        let result = Val::Em(1.)
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
+        assert_eq!(result, 20.0);
+        let result = Val::Rem(1.)
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
+        assert_eq!(result, 20.0);
     }
 
     #[test]
@@ -1374,7 +1512,7 @@ mod tests {
                 x: Val::Px(100.),
                 y: Val::Auto,
             }
-            .resolve(1., size, viewport_size),
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
             vec2(25., 25.)
         );
         assert_eq!(
@@ -1382,7 +1520,7 @@ mod tests {
                 x: Val::Px(40.),
                 y: Val::Px(40.),
             }
-            .resolve(1., size, viewport_size),
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
             vec2(40., 25.)
         );
         assert_eq!(
@@ -1390,11 +1528,11 @@ mod tests {
                 x: Val::ZERO,
                 y: Val::Px(20.),
             }
-            .resolve(1., size, viewport_size),
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
             vec2(0., 20.)
         );
         assert_eq!(
-            CornerRadius::default().resolve(1., size, viewport_size),
+            CornerRadius::default().resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
             vec2(0., 0.)
         );
     }
@@ -1407,36 +1545,54 @@ mod tests {
         for value in (-10..10).map(|value| value as f32) {
             // for a square viewport there should be no difference between `Vw` and `Vh` and between `Vmin` and `Vmax`.
             assert_eq!(
-                Val::Vw(value).resolve(1., size, viewport_size),
-                Val::Vh(value).resolve(1., size, viewport_size)
+                Val::Vw(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
+                Val::Vh(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
             );
             assert_eq!(
-                Val::VMin(value).resolve(1., size, viewport_size),
-                Val::VMax(value).resolve(1., size, viewport_size)
+                Val::VMin(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
+                Val::VMax(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
             );
             assert_eq!(
-                Val::VMin(value).resolve(1., size, viewport_size),
-                Val::Vw(value).resolve(1., size, viewport_size)
+                Val::VMin(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
+                Val::Vw(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
             );
         }
 
         let viewport_size = vec2(1000., 500.);
         assert_eq!(
-            Val::Vw(100.).resolve(1., size, viewport_size).unwrap(),
+            Val::Vw(100.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
             1000.
         );
         assert_eq!(
-            Val::Vh(100.).resolve(1., size, viewport_size).unwrap(),
+            Val::Vh(100.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
             500.
         );
-        assert_eq!(Val::Vw(60.).resolve(1., size, viewport_size).unwrap(), 600.);
-        assert_eq!(Val::Vh(40.).resolve(1., size, viewport_size).unwrap(), 200.);
         assert_eq!(
-            Val::VMin(50.).resolve(1., size, viewport_size).unwrap(),
+            Val::Vw(60.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
+            600.
+        );
+        assert_eq!(
+            Val::Vh(40.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
+            200.
+        );
+        assert_eq!(
+            Val::VMin(50.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
             250.
         );
         assert_eq!(
-            Val::VMax(75.).resolve(1., size, viewport_size).unwrap(),
+            Val::VMax(75.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
             750.
         );
     }
@@ -1445,7 +1601,7 @@ mod tests {
     fn val_auto_is_non_evaluable() {
         let size = 250.;
         let viewport_size = vec2(1000., 500.);
-        let resolve_auto = Val::Auto.resolve(1., size, viewport_size);
+        let resolve_auto = Val::Auto.resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0));
 
         assert_eq!(resolve_auto, Err(ValArithmeticError::NonEvaluable));
     }
@@ -1548,6 +1704,9 @@ mod tests {
         assert_eq!("3.5vmax".parse::<Val>(), Ok(Val::VMax(3.5)));
         assert_eq!("-3vmax".parse::<Val>(), Ok(Val::VMax(-3.)));
         assert_eq!("3.5 VMAX".parse::<Val>(), Ok(Val::VMax(3.5)));
+
+        assert_eq!("3em".parse::<Val>(), Ok(Val::Em(3.)));
+        assert_eq!("3rem".parse::<Val>(), Ok(Val::Rem(3.)));
 
         assert_eq!("".parse::<Val>(), Err(ValParseError::UnitMissing));
         assert_eq!(

--- a/crates/bevy_ui/src/gradients.rs
+++ b/crates/bevy_ui/src/gradients.rs
@@ -3,6 +3,7 @@ use bevy_color::{Color, Srgba};
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
+use bevy_text::{EmSize, RemSize};
 use bevy_utils::default;
 use core::{f32, f32::consts::TAU};
 
@@ -611,6 +612,8 @@ impl RadialGradientShape {
         scale_factor: f32,
         physical_size: Vec2,
         physical_target_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
     ) -> Vec2 {
         let half_size = 0.5 * physical_size;
         match self {
@@ -626,14 +629,32 @@ impl RadialGradientShape {
             ),
             RadialGradientShape::Circle(radius) => Vec2::splat(
                 radius
-                    .resolve(scale_factor, physical_size.x, physical_target_size)
+                    .resolve(
+                        scale_factor,
+                        physical_size.x,
+                        physical_target_size,
+                        em_size,
+                        rem_size,
+                    )
                     .unwrap_or(0.),
             ),
             RadialGradientShape::Ellipse(x, y) => Vec2::new(
-                x.resolve(scale_factor, physical_size.x, physical_target_size)
-                    .unwrap_or(0.),
-                y.resolve(scale_factor, physical_size.y, physical_target_size)
-                    .unwrap_or(0.),
+                x.resolve(
+                    scale_factor,
+                    physical_size.x,
+                    physical_target_size,
+                    em_size,
+                    rem_size,
+                )
+                .unwrap_or(0.),
+                y.resolve(
+                    scale_factor,
+                    physical_size.y,
+                    physical_target_size,
+                    em_size,
+                    rem_size,
+                )
+                .unwrap_or(0.),
             ),
         }
     }

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -148,13 +148,13 @@ impl From<AlignItems> for Option<taffy::style::AlignItems> {
     fn from(value: AlignItems) -> Self {
         match value {
             AlignItems::Default => None,
-            AlignItems::Start => taffy::style::AlignItems::Start.into(),
-            AlignItems::End => taffy::style::AlignItems::End.into(),
-            AlignItems::FlexStart => taffy::style::AlignItems::FlexStart.into(),
-            AlignItems::FlexEnd => taffy::style::AlignItems::FlexEnd.into(),
-            AlignItems::Center => taffy::style::AlignItems::Center.into(),
-            AlignItems::Baseline => taffy::style::AlignItems::Baseline.into(),
-            AlignItems::Stretch => taffy::style::AlignItems::Stretch.into(),
+            AlignItems::Start => taffy::style::AlignItems::START.into(),
+            AlignItems::End => taffy::style::AlignItems::END.into(),
+            AlignItems::FlexStart => taffy::style::AlignItems::FLEX_START.into(),
+            AlignItems::FlexEnd => taffy::style::AlignItems::FLEX_END.into(),
+            AlignItems::Center => taffy::style::AlignItems::CENTER.into(),
+            AlignItems::Baseline => taffy::style::AlignItems::BASELINE.into(),
+            AlignItems::Stretch => taffy::style::AlignItems::STRETCH.into(),
         }
     }
 }
@@ -163,11 +163,11 @@ impl From<JustifyItems> for Option<taffy::style::JustifyItems> {
     fn from(value: JustifyItems) -> Self {
         match value {
             JustifyItems::Default => None,
-            JustifyItems::Start => taffy::style::JustifyItems::Start.into(),
-            JustifyItems::End => taffy::style::JustifyItems::End.into(),
-            JustifyItems::Center => taffy::style::JustifyItems::Center.into(),
-            JustifyItems::Baseline => taffy::style::JustifyItems::Baseline.into(),
-            JustifyItems::Stretch => taffy::style::JustifyItems::Stretch.into(),
+            JustifyItems::Start => taffy::style::JustifyItems::START.into(),
+            JustifyItems::End => taffy::style::JustifyItems::END.into(),
+            JustifyItems::Center => taffy::style::JustifyItems::CENTER.into(),
+            JustifyItems::Baseline => taffy::style::JustifyItems::BASELINE.into(),
+            JustifyItems::Stretch => taffy::style::JustifyItems::STRETCH.into(),
         }
     }
 }
@@ -176,13 +176,13 @@ impl From<AlignSelf> for Option<taffy::style::AlignSelf> {
     fn from(value: AlignSelf) -> Self {
         match value {
             AlignSelf::Auto => None,
-            AlignSelf::Start => taffy::style::AlignSelf::Start.into(),
-            AlignSelf::End => taffy::style::AlignSelf::End.into(),
-            AlignSelf::FlexStart => taffy::style::AlignSelf::FlexStart.into(),
-            AlignSelf::FlexEnd => taffy::style::AlignSelf::FlexEnd.into(),
-            AlignSelf::Center => taffy::style::AlignSelf::Center.into(),
-            AlignSelf::Baseline => taffy::style::AlignSelf::Baseline.into(),
-            AlignSelf::Stretch => taffy::style::AlignSelf::Stretch.into(),
+            AlignSelf::Start => taffy::style::AlignSelf::START.into(),
+            AlignSelf::End => taffy::style::AlignSelf::END.into(),
+            AlignSelf::FlexStart => taffy::style::AlignSelf::FLEX_START.into(),
+            AlignSelf::FlexEnd => taffy::style::AlignSelf::FLEX_END.into(),
+            AlignSelf::Center => taffy::style::AlignSelf::CENTER.into(),
+            AlignSelf::Baseline => taffy::style::AlignSelf::BASELINE.into(),
+            AlignSelf::Stretch => taffy::style::AlignSelf::STRETCH.into(),
         }
     }
 }
@@ -191,11 +191,11 @@ impl From<JustifySelf> for Option<taffy::style::JustifySelf> {
     fn from(value: JustifySelf) -> Self {
         match value {
             JustifySelf::Auto => None,
-            JustifySelf::Start => taffy::style::JustifySelf::Start.into(),
-            JustifySelf::End => taffy::style::JustifySelf::End.into(),
-            JustifySelf::Center => taffy::style::JustifySelf::Center.into(),
-            JustifySelf::Baseline => taffy::style::JustifySelf::Baseline.into(),
-            JustifySelf::Stretch => taffy::style::JustifySelf::Stretch.into(),
+            JustifySelf::Start => taffy::style::JustifySelf::START.into(),
+            JustifySelf::End => taffy::style::JustifySelf::END.into(),
+            JustifySelf::Center => taffy::style::JustifySelf::CENTER.into(),
+            JustifySelf::Baseline => taffy::style::JustifySelf::BASELINE.into(),
+            JustifySelf::Stretch => taffy::style::JustifySelf::STRETCH.into(),
         }
     }
 }
@@ -204,15 +204,15 @@ impl From<AlignContent> for Option<taffy::style::AlignContent> {
     fn from(value: AlignContent) -> Self {
         match value {
             AlignContent::Default => None,
-            AlignContent::Start => taffy::style::AlignContent::Start.into(),
-            AlignContent::End => taffy::style::AlignContent::End.into(),
-            AlignContent::FlexStart => taffy::style::AlignContent::FlexStart.into(),
-            AlignContent::FlexEnd => taffy::style::AlignContent::FlexEnd.into(),
-            AlignContent::Center => taffy::style::AlignContent::Center.into(),
-            AlignContent::Stretch => taffy::style::AlignContent::Stretch.into(),
-            AlignContent::SpaceBetween => taffy::style::AlignContent::SpaceBetween.into(),
-            AlignContent::SpaceAround => taffy::style::AlignContent::SpaceAround.into(),
-            AlignContent::SpaceEvenly => taffy::style::AlignContent::SpaceEvenly.into(),
+            AlignContent::Start => taffy::style::AlignContent::START.into(),
+            AlignContent::End => taffy::style::AlignContent::END.into(),
+            AlignContent::FlexStart => taffy::style::AlignContent::FLEX_START.into(),
+            AlignContent::FlexEnd => taffy::style::AlignContent::FLEX_END.into(),
+            AlignContent::Center => taffy::style::AlignContent::CENTER.into(),
+            AlignContent::Stretch => taffy::style::AlignContent::STRETCH.into(),
+            AlignContent::SpaceBetween => taffy::style::AlignContent::SPACE_BETWEEN.into(),
+            AlignContent::SpaceAround => taffy::style::AlignContent::SPACE_AROUND.into(),
+            AlignContent::SpaceEvenly => taffy::style::AlignContent::SPACE_EVENLY.into(),
         }
     }
 }
@@ -221,15 +221,15 @@ impl From<JustifyContent> for Option<taffy::style::JustifyContent> {
     fn from(value: JustifyContent) -> Self {
         match value {
             JustifyContent::Default => None,
-            JustifyContent::Start => taffy::style::JustifyContent::Start.into(),
-            JustifyContent::End => taffy::style::JustifyContent::End.into(),
-            JustifyContent::FlexStart => taffy::style::JustifyContent::FlexStart.into(),
-            JustifyContent::FlexEnd => taffy::style::JustifyContent::FlexEnd.into(),
-            JustifyContent::Center => taffy::style::JustifyContent::Center.into(),
-            JustifyContent::Stretch => taffy::style::JustifyContent::Stretch.into(),
-            JustifyContent::SpaceBetween => taffy::style::JustifyContent::SpaceBetween.into(),
-            JustifyContent::SpaceAround => taffy::style::JustifyContent::SpaceAround.into(),
-            JustifyContent::SpaceEvenly => taffy::style::JustifyContent::SpaceEvenly.into(),
+            JustifyContent::Start => taffy::style::JustifyContent::START.into(),
+            JustifyContent::End => taffy::style::JustifyContent::END.into(),
+            JustifyContent::FlexStart => taffy::style::JustifyContent::FLEX_START.into(),
+            JustifyContent::FlexEnd => taffy::style::JustifyContent::FLEX_END.into(),
+            JustifyContent::Center => taffy::style::JustifyContent::CENTER.into(),
+            JustifyContent::Stretch => taffy::style::JustifyContent::STRETCH.into(),
+            JustifyContent::SpaceBetween => taffy::style::JustifyContent::SPACE_BETWEEN.into(),
+            JustifyContent::SpaceAround => taffy::style::JustifyContent::SPACE_AROUND.into(),
+            JustifyContent::SpaceEvenly => taffy::style::JustifyContent::SPACE_EVENLY.into(),
         }
     }
 }
@@ -562,21 +562,21 @@ mod tests {
         assert_eq!(taffy_style.flex_wrap, taffy::style::FlexWrap::WrapReverse);
         assert_eq!(
             taffy_style.align_items,
-            Some(taffy::style::AlignItems::Baseline)
+            Some(taffy::style::AlignItems::BASELINE)
         );
-        assert_eq!(taffy_style.align_self, Some(taffy::style::AlignSelf::Start));
+        assert_eq!(taffy_style.align_self, Some(taffy::style::AlignSelf::START));
         assert_eq!(
             taffy_style.align_content,
-            Some(taffy::style::AlignContent::SpaceAround)
+            Some(taffy::style::AlignContent::SPACE_AROUND)
         );
         assert_eq!(
             taffy_style.justify_content,
-            Some(taffy::style::JustifyContent::SpaceEvenly)
+            Some(taffy::style::JustifyContent::SPACE_EVENLY)
         );
         assert_eq!(taffy_style.justify_items, None);
         assert_eq!(
             taffy_style.justify_self,
-            Some(taffy::style::JustifySelf::Center)
+            Some(taffy::style::JustifySelf::CENTER)
         );
         assert_eq!(
             taffy_style.margin.left,

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -26,6 +26,10 @@ impl Val {
             }
             Val::Vw(value) => style_helpers::length(context.physical_size.x * value / 100.),
             Val::Vh(value) => style_helpers::length(context.physical_size.y * value / 100.),
+            Val::Em(value) => style_helpers::length(context.scale_factor * value * context.em_size),
+            Val::Rem(value) => {
+                style_helpers::length(context.scale_factor * value * context.rem_size)
+            }
         }
     }
 
@@ -42,6 +46,10 @@ impl Val {
             }
             Val::Vw(value) => style_helpers::length(context.physical_size.x * value / 100.),
             Val::Vh(value) => style_helpers::length(context.physical_size.y * value / 100.),
+            Val::Em(value) => style_helpers::length(context.scale_factor * value * context.em_size),
+            Val::Rem(value) => {
+                style_helpers::length(context.scale_factor * value * context.rem_size)
+            }
         }
     }
 
@@ -343,6 +351,10 @@ impl MinTrackSizingFunction {
             MinTrackSizingFunction::Percent(val) => {
                 Val::Percent(val).into_length_percentage(context).into()
             }
+            MinTrackSizingFunction::Em(val) => Val::Em(val).into_length_percentage(context).into(),
+            MinTrackSizingFunction::Rem(val) => {
+                Val::Rem(val).into_length_percentage(context).into()
+            }
             MinTrackSizingFunction::Auto => taffy::style::MinTrackSizingFunction::auto(),
             MinTrackSizingFunction::MinContent => {
                 taffy::style::MinTrackSizingFunction::min_content()
@@ -368,6 +380,10 @@ impl MaxTrackSizingFunction {
             MaxTrackSizingFunction::Px(val) => Val::Px(val).into_length_percentage(context).into(),
             MaxTrackSizingFunction::Percent(val) => {
                 Val::Percent(val).into_length_percentage(context).into()
+            }
+            MaxTrackSizingFunction::Em(val) => Val::Em(val).into_length_percentage(context).into(),
+            MaxTrackSizingFunction::Rem(val) => {
+                Val::Rem(val).into_length_percentage(context).into()
             }
             MaxTrackSizingFunction::Auto => taffy::style::MaxTrackSizingFunction::auto(),
             MaxTrackSizingFunction::MinContent => {
@@ -452,6 +468,7 @@ impl RepeatedGridTrack {
 #[cfg(test)]
 mod tests {
     use bevy_math::Vec2;
+    use bevy_text::{EmSize, RemSize, DEFAULT_REM_SIZE_PX};
 
     use crate::BorderRadius;
 
@@ -533,7 +550,12 @@ mod tests {
             grid_column: GridPlacement::start(4),
             grid_row: GridPlacement::span(3),
         };
-        let viewport_values = LayoutContext::new(1.0, Vec2::new(800., 600.));
+        let viewport_values = LayoutContext::new(
+            1.0,
+            Vec2::new(800., 600.),
+            EmSize(DEFAULT_REM_SIZE_PX),
+            RemSize(DEFAULT_REM_SIZE_PX),
+        );
         let taffy_style = from_node(&node, &viewport_values);
         assert_eq!(taffy_style.display, taffy::style::Display::Flex);
         assert_eq!(taffy_style.box_sizing, taffy::style::BoxSizing::ContentBox);
@@ -673,7 +695,7 @@ mod tests {
     #[test]
     fn test_into_length_percentage() {
         use taffy::style::LengthPercentage;
-        let context = LayoutContext::new(2.0, Vec2::new(800., 600.));
+        let context = LayoutContext::new(2.0, Vec2::new(800., 600.), EmSize(10.), RemSize(20.));
         let cases = [
             (Val::Auto, LengthPercentage::length(0.)),
             (Val::Percent(1.), LengthPercentage::percent(0.01)),
@@ -682,6 +704,8 @@ mod tests {
             (Val::Vh(1.), LengthPercentage::length(6.)),
             (Val::VMin(2.), LengthPercentage::length(12.)),
             (Val::VMax(2.), LengthPercentage::length(16.)),
+            (Val::Em(2.), LengthPercentage::length(40.)),
+            (Val::Rem(3.), LengthPercentage::length(120.)),
         ];
         for (val, length) in cases {
             assert!({

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -52,6 +52,7 @@ fn print_node(
         (_, taffy::style::Display::Flex) => "FLEX",
         (_, taffy::style::Display::Grid) => "GRID",
         (_, taffy::style::Display::Block) => "BLOCK",
+        (_, taffy::style::Display::FlowRoot) => "FLOWROOT",
     };
 
     let fork_string = if has_sibling {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -12,7 +12,7 @@ use bevy_ecs::{
     hierarchy::{ChildOf, Children},
     lifecycle::RemovedComponents,
     query::{Added, Has, With},
-    system::{Query, ResMut},
+    system::{Query, Res, ResMut},
     world::Ref,
 };
 
@@ -20,9 +20,7 @@ use bevy_math::{Affine2, Vec2};
 use bevy_sprite::BorderRect;
 use ui_surface::UiSurface;
 
-use bevy_text::ComputedTextBlock;
-
-use bevy_text::FontCx;
+use bevy_text::{ComputedTextBlock, EmSize, FontCx, RemSize, TextFont, DEFAULT_REM_SIZE_PX};
 
 use bevy_log::warn;
 
@@ -33,19 +31,30 @@ pub mod ui_surface;
 pub struct LayoutContext {
     pub scale_factor: f32,
     pub physical_size: Vec2,
+    pub em_size: f32,
+    pub rem_size: f32,
 }
 
 impl LayoutContext {
     pub const DEFAULT: Self = Self {
         scale_factor: 1.0,
         physical_size: Vec2::ZERO,
+        em_size: DEFAULT_REM_SIZE_PX,
+        rem_size: DEFAULT_REM_SIZE_PX,
     };
     /// Create a new [`LayoutContext`] from the window's physical size and scale factor
     #[inline]
-    const fn new(scale_factor: f32, physical_size: Vec2) -> Self {
+    const fn new(
+        scale_factor: f32,
+        physical_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
+    ) -> Self {
         Self {
             scale_factor,
             physical_size,
+            em_size: em_size.0,
+            rem_size: rem_size.0,
         }
     }
 }
@@ -53,14 +62,40 @@ impl LayoutContext {
 #[cfg(test)]
 impl LayoutContext {
     pub const TEST_CONTEXT: Self = Self {
-        scale_factor: 1.0,
         physical_size: Vec2::new(1000.0, 1000.0),
+        ..Self::DEFAULT
     };
 }
 
 impl Default for LayoutContext {
     fn default() -> Self {
         Self::DEFAULT
+    }
+}
+
+/// For any entity with a [`TextFont`], set [`EmSize`] to the font size resolved
+/// into pixels when the `TextFont`, render target or `RemSize` changes. Nodes
+/// without `TextFont` keep their `EmSize` intact. If `TextFont` is removed the
+/// `EmSize` remains unchanged.
+pub fn sync_font_size_to_em_size(
+    mut em_size_query: Query<
+        (&mut EmSize, Ref<TextFont>, Ref<ComputedUiRenderTargetInfo>),
+        With<Node>,
+    >,
+    rem_size: Res<RemSize>,
+) {
+    // `Val::Rem` resolves from rem size so need to recalc when this changes
+    let rem_size_changed = rem_size.is_changed();
+
+    for (mut em_size, text_font, computed_ui_render_target_info) in em_size_query.iter_mut() {
+        if text_font.is_changed() || computed_ui_render_target_info.is_changed() || rem_size_changed
+        {
+            em_size.set_if_neq(EmSize::from_font_size(
+                text_font.font_size,
+                computed_ui_render_target_info.logical_size(),
+                *rem_size,
+            ));
+        }
     }
 }
 
@@ -73,6 +108,7 @@ pub fn ui_layout_system(
     mut node_query: Query<(
         Entity,
         Ref<Node>,
+        Ref<EmSize>,
         &mut ContentSize,
         Ref<ComputedUiRenderTargetInfo>,
     )>,
@@ -83,6 +119,7 @@ pub fn ui_layout_system(
         &UiTransform,
         &mut UiGlobalTransform,
         &Node,
+        &EmSize,
         Option<&LayoutConfig>,
         Option<&Outline>,
         Option<&ScrollPosition>,
@@ -91,21 +128,36 @@ pub fn ui_layout_system(
     )>,
     mut buffer_query: Query<&mut ComputedTextBlock>,
     mut font_system: ResMut<FontCx>,
-    mut removed_children: RemovedComponents<Children>,
-    mut removed_nodes: RemovedComponents<Node>,
-    mut removed_fixed_nodes: RemovedComponents<FixedNode>,
-    #[cfg(feature = "ghost_nodes")] mut removed_ghost_nodes: RemovedComponents<GhostNode>,
-    #[cfg(feature = "ghost_nodes")] added_ghost_node_query: Query<Entity, Added<GhostNode>>,
-    #[cfg(feature = "ghost_nodes")] ghost_node_query: Query<(), With<GhostNode>>,
+    (mut removed_children, mut removed_nodes, mut removed_fixed_nodes): (
+        RemovedComponents<Children>,
+        RemovedComponents<Node>,
+        RemovedComponents<FixedNode>,
+    ),
+    rem_size: Res<RemSize>,
+    #[cfg(feature = "ghost_nodes")]
+    (mut removed_ghost_nodes, added_ghost_node_query, ghost_node_query): (
+        RemovedComponents<GhostNode>,
+        Query<Entity, Added<GhostNode>>,
+        Query<(), With<GhostNode>>,
+    ),
 ) {
+    // `Val::Rem` resolves from rem size so need to recalc when this changes
+    let rem_size_changed = rem_size.is_changed();
+
     // Sync Node and ContentSize to Taffy for all nodes
-    node_query
-        .iter_mut()
-        .for_each(|(entity, node, mut content_size, computed_target)| {
-            if computed_target.is_changed() || node.is_changed() || content_size.is_changed() {
+    node_query.iter_mut().for_each(
+        |(entity, node, em_size, mut content_size, computed_target)| {
+            if computed_target.is_changed()
+                || node.is_changed()
+                || content_size.is_changed()
+                || rem_size_changed
+                || em_size.is_changed()
+            {
                 let layout_context = LayoutContext::new(
                     computed_target.scale_factor,
                     computed_target.physical_size.as_vec2(),
+                    *em_size,
+                    *rem_size,
                 );
                 if content_size.is_changed() && content_size.measure.is_none() {
                     ui_surface.try_remove_node_context(entity);
@@ -113,7 +165,8 @@ pub fn ui_layout_system(
                 let measure = content_size.bypass_change_detection().measure.take();
                 ui_surface.upsert_node(&layout_context, entity, &node, measure);
             }
-        });
+        },
+    );
 
     // update and remove children
     #[cfg(not(feature = "ghost_nodes"))]
@@ -210,7 +263,7 @@ pub fn ui_layout_system(
             ui_root_entity,
         );
 
-        let Ok((_, _, _, computed_target)) = node_query.get(ui_root_entity) else {
+        let Ok((_, _, _, _, computed_target)) = node_query.get(ui_root_entity) else {
             warn!("UI root {ui_root_entity} not found");
             continue;
         };
@@ -234,6 +287,7 @@ pub fn ui_layout_system(
             computed_target.scale_factor.recip(),
             Vec2::ZERO,
             Vec2::ZERO,
+            *rem_size,
         );
     }
 
@@ -250,6 +304,7 @@ pub fn ui_layout_system(
             &UiTransform,
             &mut UiGlobalTransform,
             &Node,
+            &EmSize,
             Option<&LayoutConfig>,
             Option<&Outline>,
             Option<&ScrollPosition>,
@@ -260,12 +315,14 @@ pub fn ui_layout_system(
         inverse_target_scale_factor: f32,
         parent_size: Vec2,
         parent_scroll_position: Vec2,
+        rem_size: RemSize,
     ) {
         if let Ok((
             mut node,
             transform,
             mut global_transform,
             style,
+            em_size,
             maybe_layout_config,
             maybe_outline,
             maybe_scroll_position,
@@ -328,11 +385,20 @@ pub fn ui_layout_system(
                 node.padding = new_padding;
             }
 
+            if node.em_size != *em_size {
+                node.em_size = *em_size;
+            }
+            if node.rem_size != rem_size {
+                node.rem_size = rem_size;
+            }
+
             // Compute the node's new global transform
             let mut local_transform = transform.compute_affine(
                 inverse_target_scale_factor.recip(),
                 layout_size,
                 target_size,
+                *em_size,
+                rem_size,
             );
             local_transform.translation += local_center;
             inherited_transform *= local_transform;
@@ -347,6 +413,8 @@ pub fn ui_layout_system(
                 inverse_target_scale_factor.recip(),
                 node.size,
                 target_size,
+                *em_size,
+                rem_size,
             );
             if node.border_radius != new_border_radius {
                 node.border_radius = new_border_radius;
@@ -361,6 +429,8 @@ pub fn ui_layout_system(
                             inverse_target_scale_factor.recip(),
                             node.size().x,
                             target_size,
+                            *em_size,
+                            rem_size,
                         )
                         .unwrap_or(0.)
                         .max(0.)
@@ -378,6 +448,8 @@ pub fn ui_layout_system(
                         inverse_target_scale_factor.recip(),
                         node.size().x,
                         target_size,
+                        *em_size,
+                        rem_size,
                     )
                     .unwrap_or(0.)
                     // Clamp outline offsets to at least the length of the node's shorter side
@@ -434,6 +506,7 @@ pub fn ui_layout_system(
                     inverse_target_scale_factor,
                     layout_size,
                     physical_scroll_position,
+                    rem_size,
                 );
             }
         }
@@ -473,6 +546,7 @@ mod tests {
         app.init_resource::<UiSurface>();
         app.init_resource::<bevy_text::TextPipeline>();
         app.init_resource::<bevy_text::FontCx>();
+        app.init_resource::<RemSize>();
         app.init_resource::<bevy_text::ScaleCx>();
         app.init_resource::<bevy_transform::StaticTransformOptimizations>();
 
@@ -1269,9 +1343,8 @@ mod tests {
         world.init_resource::<UiSurface>();
 
         world.init_resource::<bevy_text::TextPipeline>();
-
         world.init_resource::<bevy_text::FontCx>();
-
+        world.init_resource::<RemSize>();
         world.init_resource::<bevy_text::ScaleCx>();
 
         let ui_root = world

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -211,8 +211,8 @@ impl UiSurface {
                             width: taffy::style_helpers::percent(1.0_f32),
                             height: taffy::style_helpers::percent(1.0_f32),
                         },
-                        align_items: Some(taffy::style::AlignItems::Start),
-                        justify_items: Some(taffy::style::JustifyItems::Start),
+                        align_items: Some(taffy::style::AlignItems::START),
+                        justify_items: Some(taffy::style::JustifyItems::START),
                         ..default()
                     })
                     .unwrap();

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -195,6 +195,12 @@ impl UiSurface {
             .entry(ui_root_entity)
             .or_insert_with(|| {
                 let root_node = self.entity_to_taffy.get_mut(&ui_root_entity).unwrap();
+
+                // remove parent node to avoid a potential panic (invalid SlotMap key used) when this `NodeId` is `remove`d
+                if let Some(parent_node) = self.taffy.parent(root_node.id) {
+                    let _ = self.taffy.remove_child(parent_node, root_node.id);
+                };
+
                 let implicit_root = self
                     .taffy
                     .new_leaf(Style {

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -79,7 +79,7 @@ pub mod prelude {
         },
         // `bevy_sprite` re-exports for texture slicing
         bevy_sprite::{BorderRect, SliceScaleMode, SpriteImageMode, TextureSlicer},
-        bevy_text::TextBackgroundColor,
+        bevy_text::{EmSize, RemSize, TextBackgroundColor},
     };
 }
 
@@ -292,6 +292,9 @@ fn build_text_interop(app: &mut App) {
                 .ambiguous_with(widget::text_system)
                 .ambiguous_with(bevy_sprite::update_text2d_layout)
                 .ambiguous_with(bevy_sprite::calculate_bounds_text2d),
+            sync_font_size_to_em_size
+                .in_set(UiSystems::Content)
+                .after(bevy_text::load_font_assets_into_font_collection),
         ),
     );
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -11,7 +11,7 @@ use bevy_reflect::prelude::*;
 use bevy_sprite::BorderRect;
 use bevy_utils::once;
 use bevy_window::{PrimaryWindow, WindowRef};
-use core::{f32, num::NonZero};
+use core::num::NonZero;
 use derive_more::derive::From;
 use smallvec::SmallVec;
 use thiserror::Error;

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -9,6 +9,7 @@ use bevy_ecs::{prelude::*, system::SystemParam};
 use bevy_math::{Affine2, BVec2, Rect, UVec2, Vec2, Vec4, Vec4Swizzles};
 use bevy_reflect::prelude::*;
 use bevy_sprite::BorderRect;
+use bevy_text::{EmSize, RemSize, DEFAULT_REM_SIZE_PX};
 use bevy_utils::once;
 use bevy_window::{PrimaryWindow, WindowRef};
 use core::num::NonZero;
@@ -43,35 +44,30 @@ pub struct ComputedNode {
     pub scroll_position: Vec2,
     /// The width of this node's outline in physical pixels.
     /// If this value is negative or zero then no outline will be rendered.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub outline_width: f32,
     /// The amount of space between the outline and the edge of the node.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub outline_offset: f32,
     /// The unrounded size of the node as width and height in physical pixels.
     pub unrounded_size: Vec2,
     /// Resolved border values in physical pixels.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub border: BorderRect,
     /// Resolved border radius values in physical pixels.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub border_radius: ResolvedBorderRadius,
     /// Resolved padding values in physical pixels.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub padding: BorderRect,
     /// Inverse scale factor for this Node.
     /// Multiply physical coordinates by the inverse scale factor to give logical coordinates.
     pub inverse_scale_factor: f32,
+    /// The font size used to resolve this node's `Val::Em` lengths, in logical pixels.
+    ///
+    /// Copied from the node's [`EmSize`] component during layout.
+    pub em_size: EmSize,
+    /// The root font size used to resolve this node's `Val::Rem` lengths, in logical pixels.
+    ///
+    /// Copied from the [`RemSize`] resource during layout.
+    // Stored per node rather than read from the resource because `ComputedNode` is extracted
+    // to the render world and `RemSize` is not.
+    pub rem_size: RemSize,
 }
 
 impl ComputedNode {
@@ -389,6 +385,8 @@ impl ComputedNode {
         border: BorderRect::ZERO,
         padding: BorderRect::ZERO,
         inverse_scale_factor: 1.,
+        em_size: EmSize(DEFAULT_REM_SIZE_PX),
+        rem_size: RemSize(DEFAULT_REM_SIZE_PX),
     };
 }
 
@@ -474,7 +472,8 @@ impl From<BVec2> for IgnoreScroll {
     FocusPolicy,
     ScrollPosition,
     Visibility,
-    ZIndex
+    ZIndex,
+    EmSize
 )]
 #[reflect(Component, Default, PartialEq, Debug, Clone)]
 #[cfg_attr(
@@ -1543,6 +1542,10 @@ pub enum MinTrackSizingFunction {
     Px(f32),
     /// Track minimum size should be a percentage value
     Percent(f32),
+    /// Track minimum size should be a multiple of the grid container's font size.
+    Em(f32),
+    /// Track minimum size should be a multiple of the root font size.
+    Rem(f32),
     /// Track minimum size should be content sized under a min-content constraint
     MinContent,
     /// Track minimum size should be content sized under a max-content constraint
@@ -1572,6 +1575,10 @@ pub enum MaxTrackSizingFunction {
     Px(f32),
     /// Track maximum size should be a percentage value
     Percent(f32),
+    /// Track maximum size should be a multiple of the grid container's font size.
+    Em(f32),
+    /// Track maximum size should be a multiple of the root font size.
+    Rem(f32),
     /// Track maximum size should be content sized under a min-content constraint
     MinContent,
     /// Track maximum size should be content sized under a max-content constraint
@@ -1632,6 +1639,24 @@ impl GridTrack {
         Self {
             min_sizing_function: MinTrackSizingFunction::Percent(value),
             max_sizing_function: MaxTrackSizingFunction::Percent(value),
+        }
+        .into()
+    }
+
+    /// Create a grid track with size as a multiple of the grid container's font size.
+    pub fn em<T: From<Self>>(value: f32) -> T {
+        Self {
+            min_sizing_function: MinTrackSizingFunction::Em(value),
+            max_sizing_function: MaxTrackSizingFunction::Em(value),
+        }
+        .into()
+    }
+
+    /// Create a grid track with size as a multiple of the root font size.
+    pub fn rem<T: From<Self>>(value: f32) -> T {
+        Self {
+            min_sizing_function: MinTrackSizingFunction::Rem(value),
+            max_sizing_function: MaxTrackSizingFunction::Rem(value),
         }
         .into()
     }
@@ -1841,6 +1866,24 @@ impl RepeatedGridTrack {
         Self {
             repetition: repetition.into(),
             tracks: SmallVec::from_buf([GridTrack::percent(value)]),
+        }
+        .into()
+    }
+
+    /// Create a repeating set of grid tracks with size as a multiple of the grid containers's font size.
+    pub fn em<T: From<Self>>(repetition: impl Into<GridTrackRepetition>, value: f32) -> T {
+        Self {
+            repetition: repetition.into(),
+            tracks: SmallVec::from_buf([GridTrack::em(value)]),
+        }
+        .into()
+    }
+
+    /// Create a repeating set of grid tracks with size as a multiple of the root font size.
+    pub fn rem<T: From<Self>>(repetition: impl Into<GridTrackRepetition>, value: f32) -> T {
+        Self {
+            repetition: repetition.into(),
+            tracks: SmallVec::from_buf([GridTrack::rem(value)]),
         }
         .into()
     }
@@ -2852,20 +2895,38 @@ impl BorderRadius {
         scale_factor: f32,
         node_size: Vec2,
         viewport_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
     ) -> ResolvedBorderRadius {
         ResolvedBorderRadius {
-            top_left: self
-                .top_left
-                .resolve(scale_factor, node_size, viewport_size),
-            top_right: self
-                .top_right
-                .resolve(scale_factor, node_size, viewport_size),
-            bottom_left: self
-                .bottom_left
-                .resolve(scale_factor, node_size, viewport_size),
-            bottom_right: self
-                .bottom_right
-                .resolve(scale_factor, node_size, viewport_size),
+            top_left: self.top_left.resolve(
+                scale_factor,
+                node_size,
+                viewport_size,
+                em_size,
+                rem_size,
+            ),
+            top_right: self.top_right.resolve(
+                scale_factor,
+                node_size,
+                viewport_size,
+                em_size,
+                rem_size,
+            ),
+            bottom_left: self.bottom_left.resolve(
+                scale_factor,
+                node_size,
+                viewport_size,
+                em_size,
+                rem_size,
+            ),
+            bottom_right: self.bottom_right.resolve(
+                scale_factor,
+                node_size,
+                viewport_size,
+                em_size,
+                rem_size,
+            ),
         }
     }
 }

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -9,6 +9,7 @@ use bevy_math::Mat2;
 use bevy_math::Rot2;
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
+use bevy_text::{EmSize, RemSize};
 use core::ops::Mul;
 
 /// A pair of [`Val`]s used to represent a 2-dimensional size or offset.
@@ -60,13 +61,20 @@ impl Val2 {
     /// and `viewport_size`.
     ///
     /// Component values of [`Val::Auto`] are resolved to 0.
-    pub fn resolve(&self, scale_factor: f32, base_size: Vec2, viewport_size: Vec2) -> Vec2 {
+    pub fn resolve(
+        &self,
+        scale_factor: f32,
+        base_size: Vec2,
+        viewport_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
+    ) -> Vec2 {
         Vec2::new(
             self.x
-                .resolve(scale_factor, base_size.x, viewport_size)
+                .resolve(scale_factor, base_size.x, viewport_size, em_size, rem_size)
                 .unwrap_or(0.),
             self.y
-                .resolve(scale_factor, base_size.y, viewport_size)
+                .resolve(scale_factor, base_size.y, viewport_size, em_size, rem_size)
                 .unwrap_or(0.),
         )
     }
@@ -183,11 +191,18 @@ impl UiTransform {
 
     /// Resolves the translation from the given `scale_factor`, `base_value`, and `target_size`
     /// and returns a 2d affine transform from the resolved translation, and the `UiTransform`'s rotation, and scale.
-    pub fn compute_affine(&self, scale_factor: f32, base_size: Vec2, target_size: Vec2) -> Affine2 {
+    pub fn compute_affine(
+        &self,
+        scale_factor: f32,
+        base_size: Vec2,
+        target_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
+    ) -> Affine2 {
         Affine2::from_mat2_translation(
             Mat2::from(self.rotation) * Mat2::from_diagonal(self.scale),
             self.translation
-                .resolve(scale_factor, base_size, target_size),
+                .resolve(scale_factor, base_size, target_size, em_size, rem_size),
         )
     }
 }

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -186,6 +186,13 @@ impl ImageNode {
         self.image_mode = mode;
         self
     }
+
+    /// Set the region within the UI node where the image should be drawn.
+    #[must_use]
+    pub const fn with_visual_box(mut self, visual_box: VisualBox) -> Self {
+        self.visual_box = visual_box;
+        self
+    }
 }
 
 impl From<Handle<Image>> for ImageNode {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -322,7 +322,7 @@ pub fn measure_text_system(
             &mut font_system,
             &mut layout_cx,
             computed_target.logical_size(),
-            rem_size.0,
+            *rem_size,
         ) {
             Ok(measure) => {
                 if block.linebreak == LineBreak::NoWrap {

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -206,14 +206,16 @@ pub fn update_editable_text_styles(
                 ));
         }
 
-        if text_font.is_changed() {
-            let Ok(resolved_family) = text_font.font.resolve_font_family(fonts.as_ref()) else {
-                continue;
-            };
-
+        if text_font.is_changed()
+            && let Ok(resolved_family) = text_font.font.resolve_font_family(fonts.as_ref())
+        {
             let family = resolved_family.into_owned();
             let style_set = editable_text.editor.edit_styles();
             style_set.insert(StyleProperty::FontFamily(family));
+        }
+
+        if text_font.is_changed() {
+            let style_set = editable_text.editor.edit_styles();
             style_set.insert(StyleProperty::FontWeight(text_font.weight.into()));
             style_set.insert(StyleProperty::FontWidth(text_font.width.into()));
             style_set.insert(StyleProperty::FontStyle(text_font.style.into()));

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -92,7 +92,7 @@ pub fn update_editable_text_content_size(
             continue;
         }
 
-        let font_size = text_font.font_size.eval(target.logical_size(), rem_size.0);
+        let font_size = text_font.font_size.eval(target.logical_size(), *rem_size);
 
         let width = editable_text.visible_width.and_then(|visible_width| {
             let font_context = &mut font_cx.context;
@@ -202,7 +202,7 @@ pub fn update_editable_text_styles(
                 .editor
                 .edit_styles()
                 .insert(StyleProperty::FontSize(
-                    text_font.font_size.eval(target.logical_size(), rem_size.0),
+                    text_font.font_size.eval(target.logical_size(), *rem_size),
                 ));
         }
 
@@ -505,7 +505,7 @@ pub fn update_editable_text_layout(
             info.cursor = driver
                 .editor
                 .cursor_geometry(
-                    cursor_width * text_font.font_size.eval(target.logical_size(), rem_size.0),
+                    cursor_width * text_font.font_size.eval(target.logical_size(), *rem_size),
                 )
                 .map(bounding_box_to_rect)
                 .map(|rect| (*cursor_timer < cursor_blink_period / 2, rect));

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -321,6 +321,8 @@ pub fn extract_shadows(
                 Val::Vh(percent) => percent / 100. * ui_physical_viewport_size.y,
                 Val::VMin(percent) => percent / 100. * ui_physical_viewport_size.min_element(),
                 Val::VMax(percent) => percent / 100. * ui_physical_viewport_size.max_element(),
+                Val::Em(em) => em * uinode.em_size.0 * scale_factor,
+                Val::Rem(rem) => rem * uinode.rem_size.0 * scale_factor,
             };
 
             let spread_x = resolve_val(drop_shadow.spread_radius, uinode.size().x, scale_factor);

--- a/crates/bevy_ui_render/src/box_shadow.wesl
+++ b/crates/bevy_ui_render/src/box_shadow.wesl
@@ -1,6 +1,6 @@
 import bevy_render::view::View;
 import bevy_render::globals::Globals;
-import bevy_ui_render::ui::{
+import package::ui::{
     select_corner_radius
 };
 

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -32,6 +32,7 @@ use bevy_render::{
 use bevy_render::{GpuResourceAppExt, RenderStartup};
 use bevy_shader::Shader;
 use bevy_sprite::BorderRect;
+use bevy_text::{EmSize, RemSize};
 use bevy_ui::{
     BackgroundGradient, BorderGradient, ColorStop, ComputedStackIndex, ComputedUiRenderTargetInfo,
     ConicGradient, Gradient, InterpolationColorSpace, LinearGradient, RadialGradient,
@@ -294,13 +295,15 @@ fn compute_color_stops(
     length: f32,
     target_size: Vec2,
     scratch: &mut Vec<(LinearRgba, f32, f32)>,
+    em_size: EmSize,
+    rem_size: RemSize,
 ) -> Vec<(LinearRgba, f32, f32)> {
     let mut extracted_color_stops = vec![];
 
     // resolve the physical distances of explicit stops and sort them
     scratch.extend(stops.iter().filter_map(|stop| {
         stop.point
-            .resolve(scale_factor, length, target_size)
+            .resolve(scale_factor, length, target_size, em_size, rem_size)
             .ok()
             .map(|physical_point| (stop.color.to_linear(), physical_point, stop.hint))
     }));
@@ -470,6 +473,8 @@ pub fn extract_gradients(
                         length,
                         target.physical_size().as_vec2(),
                         &mut sorted_stops,
+                        uinode.em_size,
+                        uinode.rem_size,
                     );
                     extracted_gradients
                         .items
@@ -510,6 +515,8 @@ pub fn extract_gradients(
                             length,
                             target.physical_size().as_vec2(),
                             &mut sorted_stops,
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         extracted_gradients
@@ -546,6 +553,8 @@ pub fn extract_gradients(
                             target.scale_factor(),
                             uinode.size,
                             target.physical_size().as_vec2(),
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         let size = shape.resolve(
@@ -553,6 +562,8 @@ pub fn extract_gradients(
                             target.scale_factor(),
                             uinode.size,
                             target.physical_size().as_vec2(),
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         let length = size.x;
@@ -563,6 +574,8 @@ pub fn extract_gradients(
                             length,
                             target.physical_size().as_vec2(),
                             &mut sorted_stops,
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         extracted_gradients
@@ -599,6 +612,8 @@ pub fn extract_gradients(
                             target.scale_factor(),
                             uinode.size,
                             target.physical_size().as_vec2(),
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         // sort the explicit stops

--- a/crates/bevy_ui_render/src/gradient.wesl
+++ b/crates/bevy_ui_render/src/gradient.wesl
@@ -1,5 +1,5 @@
 import bevy_render::view::View;
-import bevy_ui_render::ui::{
+import package::ui::{
     draw_uinode_background,
     draw_uinode_border,
 };

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -850,6 +850,7 @@ pub fn extract_uinode_images(
             VisualBox::PaddingBox => uinode.padding_box(),
             VisualBox::BorderBox => uinode.border_box(),
         };
+
         // Skip invisible images
         if !inherited_visibility.get()
             || image.color.is_fully_transparent()
@@ -873,6 +874,28 @@ pub fn extract_uinode_images(
             }
         } else {
             visual_box.size()
+        };
+
+        // The node's border radius is subtracted from the visual box target's edge insets
+        // and then clamped to get the corner radius for the image. Ideally this should be handled
+        // on the GPU, but that might need changes to `ui.wesl`'s UV calculations.
+        let mut inset = match image.visual_box {
+            VisualBox::ContentBox => uinode.content_inset(),
+            VisualBox::PaddingBox => uinode.border(),
+            VisualBox::BorderBox => BorderRect::ZERO,
+        };
+        let image_inset = 0.5 * (visual_box.size() - size);
+        inset.min_inset += image_inset;
+        inset.max_inset += image_inset;
+
+        let radius = uinode.border_radius();
+        let clamped_radius = ResolvedBorderRadius {
+            top_left: (radius.top_left - inset.min_inset).clamp(Vec2::ZERO, 0.5 * size),
+            top_right: (radius.top_right - Vec2::new(inset.max_inset.x, inset.min_inset.y))
+                .clamp(Vec2::ZERO, 0.5 * size),
+            bottom_right: (radius.bottom_right - inset.max_inset).clamp(Vec2::ZERO, 0.5 * size),
+            bottom_left: (radius.bottom_left - Vec2::new(inset.min_inset.x, inset.max_inset.y))
+                .clamp(Vec2::ZERO, 0.5 * size),
         };
 
         let atlas_rect = image
@@ -924,7 +947,7 @@ pub fn extract_uinode_images(
                         flip_x: image.flip_x,
                         flip_y: image.flip_y,
                         border: BorderRect::ZERO,
-                        border_radius: uinode.border_radius,
+                        border_radius: clamped_radius,
                         node_type: NodeType::Rect,
                     },
                 },

--- a/crates/bevy_ui_render/src/ui_material.wesl
+++ b/crates/bevy_ui_render/src/ui_material.wesl
@@ -2,7 +2,7 @@ import bevy_render::{
     view::View,
     globals::Globals,
 };
-import bevy_ui_render::ui_vertex_output::UiVertexOutput;
+import package::ui_vertex_output::UiVertexOutput;
 
 @group(0) @binding(0)
 var<uniform> view: View;

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -253,6 +253,8 @@ pub(crate) fn position_popover(
                 computed_target.scale_factor(),
                 computed_node.size(),
                 computed_target.physical_size().as_vec2(),
+                computed_node.em_size,
+                computed_node.rem_size,
             );
             let logical_translation = (resolved_translation
                 + parent_matrix.inverse() * physical_translation)

--- a/crates/bevy_ui_widgets/src/scrollbar.rs
+++ b/crates/bevy_ui_widgets/src/scrollbar.rs
@@ -404,6 +404,8 @@ pub(crate) fn update_scrollbar_thumb(
                 target_info.scale_factor(),
                 thumb_physical_size,
                 target_info.physical_size().as_vec2(),
+                thumb_node.em_size,
+                thumb_node.rem_size,
             );
             if thumb_node.border_radius != border_radius {
                 thumb_node.border_radius = border_radius;
@@ -414,6 +416,8 @@ pub(crate) fn update_scrollbar_thumb(
                     target_info.scale_factor(),
                     thumb_physical_size.x,
                     target_info.physical_size().as_vec2(),
+                    thumb_node.em_size,
+                    thumb_node.rem_size,
                 )
                 .unwrap_or(0.)
             };
@@ -450,6 +454,8 @@ pub(crate) fn update_scrollbar_thumb(
                     target_info.scale_factor(),
                     thumb_physical_size,
                     target_info.physical_size().as_vec2(),
+                    thumb_node.em_size,
+                    thumb_node.rem_size,
                 )
                 * Affine2::from_translation(thumb_center * target_info.scale_factor());
 

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -11,9 +11,9 @@ use bevy_ecs::{
 };
 use bevy_input::keyboard::{Key, KeyCode, KeyboardFocusLost, KeyboardInput};
 use bevy_window::{
-    ClosingWindow, CursorOptions, Monitor, OnMonitor, PrimaryMonitor, RawHandleWrapper, VideoMode,
-    Window, WindowClosed, WindowClosing, WindowCreated, WindowEvent, WindowFocused, WindowMode,
-    WindowResized, WindowScaleFactorChanged, WindowWrapper,
+    ClosingWindow, CursorOptions, HasWindows, Monitor, OnMonitor, PrimaryMonitor, RawHandleWrapper,
+    VideoMode, Window, WindowClosed, WindowClosing, WindowCreated, WindowEvent, WindowFocused,
+    WindowMode, WindowResized, WindowScaleFactorChanged, WindowWrapper,
 };
 use tracing::{error, info, warn};
 
@@ -237,7 +237,14 @@ pub fn create_monitors(
             true
         } else {
             info!("Monitor removed {}", entity);
-            commands.entity(*entity).despawn();
+
+            commands
+                .entity(*entity)
+                // Remove the monitor's linked windows before despawning
+                //  it to prevent those windows from being despawned too.
+                .remove::<HasWindows>()
+                .despawn();
+
             idx += 1;
             false
         }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -159,6 +159,7 @@ This is the complete `bevy` cargo feature list, without "profiles" or "collectio
 |mp4|MP4 audio format support (through `symphonia`). It also enables AAC support.|
 |multi_threaded|Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.|
 |pan_camera|Enables the pan camera from bevy_camera_controller|
+|pan_orbit_camera|Enables the pan orbit camera from bevy_camera_controller|
 |pbr_anisotropy_texture|Enable support for anisotropy texture in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
 |pbr_clustered_decals|Enable support for Clustered Decals|
 |pbr_light_textures|Enable support for Light Textures|

--- a/examples/README.md
+++ b/examples/README.md
@@ -303,7 +303,10 @@ Example | Description
 [Custom Projection](../examples/camera/custom_projection.rs) | Shows how to create custom camera projections.
 [First person view model](../examples/camera/first_person_view_model.rs) | A first-person camera that uses a world model and a view model with different field of views (FOV)
 [Free Camera controller](../examples/camera/free_camera_controller.rs) | Demonstrates the FreeCamera controller for 3D scenes.
+[Minimal Pan Orbit Camera](../examples/camera/pan_orbit_camera_minimal.rs) | Minimum setup for working PanOrbitCamera
+[Orthographic Pan Orbit Camera](../examples/camera/pan_orbit_camera_ortho.rs) | Using Pan Orbit Camera in orthographic-only projection
 [Pan Camera](../examples/camera/pan_camera_controller.rs) | Example Pan-Camera Styled Camera Controller for 2D scenes
+[Pan Orbit Camera](../examples/camera/pan_orbit_camera_cad.rs) | CAD-like controls and setup for PanOrbitCamera
 [Projection Zoom](../examples/camera/projection_zoom.rs) | Shows how to zoom orthographic and perspective projection cameras.
 [Screen Shake](../examples/camera/2d_screen_shake.rs) | A simple 2D screen shake effect
 

--- a/examples/camera/pan_orbit_camera_cad.rs
+++ b/examples/camera/pan_orbit_camera_cad.rs
@@ -1,0 +1,303 @@
+//! Showcases how a pan-orbit-zoom camera can be used to inspect a CAD model.
+//!
+//! Features:
+//! - Smoothly between perspective and orthographic projection (P)
+//! - Toggle between free and constrained orbit (should the camera always be "facing up"?) (C)
+//! - Snap to 6 axis-aligned views (1-6)
+//! - Explode the model, separating its parts for inspection (E)
+//! - Toggling passing thought surface on minimal zool (Z)
+
+use std::time::Duration;
+
+use bevy::camera::Hdr;
+use bevy::camera_controller::pan_orbit_camera::{
+    extensions::{dolly_zoom::DollyZoomTrigger, look_to::LookToTrigger},
+    prelude::*,
+};
+use bevy::math::DVec3;
+use bevy::{
+    anti_alias::smaa::Smaa, camera::primitives::Aabb, core_pipeline::tonemapping::Tonemapping,
+    pbr::ScreenSpaceAmbientOcclusion, platform::time::Instant, post_process::bloom::Bloom,
+    prelude::*, window::RequestRedraw,
+};
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            DefaultPanOrbitCameraPlugins,
+            MeshPickingPlugin,
+        ))
+        // The camera controller works with reactive rendering:
+        // .insert_resource(bevy::winit::WinitSettings::desktop_app())
+        .insert_resource(GlobalAmbientLight::NONE)
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            (
+                toggle_projection,
+                toggle_constraint,
+                explode,
+                switch_direction,
+                toggle_zoom,
+            )
+                .chain(),
+        )
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // Original envmaps:
+    // let diffuse_map = asset_server.load(get_web_asset_url("bevy_editor_cam_environment_maps/diffuse_rgb9e5_zstd.ktx2"));
+    // let specular_map = asset_server.load(get_web_asset_url("bevy_editor_cam_environment_maps/specular_rgb9e5_zstd.ktx2"));
+    // let intensity = 1000.0;
+
+    let diffuse_map = asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2");
+    let specular_map = asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2");
+    let intensity = 5000.0;
+
+    let scene = asset_server.load(get_web_asset_url("PlaneEngine/scene.gltf#Scene0"));
+
+    commands.spawn((
+        WorldAssetRoot(scene),
+        Transform::from_scale(Vec3::splat(2.0)),
+    ));
+
+    let cam_trans = Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y);
+    let camera = commands
+        .spawn((
+            Camera3d::default(),
+            Hdr,
+            Camera::default(),
+            cam_trans,
+            Tonemapping::AcesFitted,
+            Bloom::default(),
+            EnvironmentMapLight {
+                intensity,
+                diffuse_map: diffuse_map.clone(),
+                specular_map: specular_map.clone(),
+                ..Default::default()
+            },
+            PanOrbitCamera {
+                orbit_constraint: OrbitConstraint::Free,
+                last_anchor_depth: -cam_trans.translation.length() as f64,
+                orthographic: projections::OrthographicSettings {
+                    scale_to_near_clip: 1_000_f32, // Needed for SSAO to work in ortho
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ScreenSpaceAmbientOcclusion::default(),
+            Smaa::default(),
+            Msaa::Off,
+        ))
+        .id();
+
+    setup_ui(commands, camera);
+}
+
+fn toggle_projection(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut dolly: MessageWriter<DollyZoomTrigger>,
+    cam: Query<Entity, With<PanOrbitCamera>>,
+    mut toggled: Local<bool>,
+) {
+    if keys.just_pressed(KeyCode::KeyP) {
+        *toggled = !*toggled;
+        let target_projection = if *toggled {
+            Projection::Orthographic(OrthographicProjection::default_3d())
+        } else {
+            Projection::Perspective(PerspectiveProjection::default())
+        };
+        dolly.write(DollyZoomTrigger {
+            target_projection,
+            camera: cam.single().unwrap(),
+        });
+    }
+}
+
+#[derive(Component)]
+struct ZoomStatusIndicator;
+
+fn zoom_status(zoom_through: bool) -> String {
+    format!("Zoom Through: {zoom_through}")
+}
+
+fn toggle_zoom(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut cam: Query<&mut PanOrbitCamera>,
+    mut text: Query<&mut Text, With<ZoomStatusIndicator>>,
+) {
+    if keys.just_pressed(KeyCode::KeyZ) {
+        let mut editor = cam.single_mut().unwrap();
+        editor.zoom_limits.zoom_through_objects = !editor.zoom_limits.zoom_through_objects;
+        text.single_mut().unwrap().0 = zoom_status(editor.zoom_limits.zoom_through_objects);
+    }
+}
+
+fn toggle_constraint(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut cam: Query<(Entity, &Transform, &mut PanOrbitCamera)>,
+    mut look_to: MessageWriter<LookToTrigger>,
+) {
+    if keys.just_pressed(KeyCode::KeyC) {
+        let (entity, transform, mut editor) = cam.single_mut().unwrap();
+        match editor.orbit_constraint {
+            OrbitConstraint::Fixed { .. } => editor.orbit_constraint = OrbitConstraint::Free,
+            OrbitConstraint::Free => {
+                editor.orbit_constraint = OrbitConstraint::Fixed {
+                    up: DVec3::Y,
+                    can_pass_tdc: false,
+                };
+
+                look_to.write(LookToTrigger::auto_snap_up_direction(
+                    transform.forward().as_dvec3(),
+                    entity,
+                    &transform.rotation.as_dquat(),
+                    editor.as_ref(),
+                ));
+            }
+        };
+    }
+}
+
+fn switch_direction(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut look_to: MessageWriter<LookToTrigger>,
+    cam: Query<(Entity, &Transform, &PanOrbitCamera)>,
+) {
+    let (camera, transform, editor) = cam.single().unwrap();
+    if keys.just_pressed(KeyCode::Digit1) {
+        look_to.write(LookToTrigger::auto_snap_up_direction(
+            DVec3::X,
+            camera,
+            &transform.rotation.as_dquat(),
+            editor,
+        ));
+    }
+    if keys.just_pressed(KeyCode::Digit2) {
+        look_to.write(LookToTrigger::auto_snap_up_direction(
+            DVec3::Z,
+            camera,
+            &transform.rotation.as_dquat(),
+            editor,
+        ));
+    }
+    if keys.just_pressed(KeyCode::Digit3) {
+        look_to.write(LookToTrigger::auto_snap_up_direction(
+            DVec3::NEG_X,
+            camera,
+            &transform.rotation.as_dquat(),
+            editor,
+        ));
+    }
+    if keys.just_pressed(KeyCode::Digit4) {
+        look_to.write(LookToTrigger::auto_snap_up_direction(
+            DVec3::NEG_Z,
+            camera,
+            &transform.rotation.as_dquat(),
+            editor,
+        ));
+    }
+    if keys.just_pressed(KeyCode::Digit5) {
+        look_to.write(LookToTrigger::auto_snap_up_direction(
+            DVec3::Y,
+            camera,
+            &transform.rotation.as_dquat(),
+            editor,
+        ));
+    }
+    if keys.just_pressed(KeyCode::Digit6) {
+        look_to.write(LookToTrigger::auto_snap_up_direction(
+            DVec3::NEG_Y,
+            camera,
+            &transform.rotation.as_dquat(),
+            editor,
+        ));
+    }
+}
+
+fn setup_ui(mut commands: Commands, camera: Entity) {
+    let text = "\
+Left Mouse  - Pan
+Right Mouse - Orbit
+Scroll      - Zoom
+Z           - Toggle passing thought surface on minimal zoom
+P           - Toggle projection
+C           - Toggle orbit constraint
+E           - Toggle explode
+1-6         - Switch direction";
+    commands.spawn((
+        children![
+            Text::new(text),
+            (Text::new(zoom_status(false)), ZoomStatusIndicator),
+        ],
+        TextFont {
+            font_size: FontSize::Px(20.0),
+            ..default()
+        },
+        Node {
+            margin: UiRect::all(Val::Px(20.0)),
+            flex_direction: FlexDirection::Column,
+            ..Default::default()
+        },
+        Pickable::IGNORE,
+        UiTargetCamera(camera),
+    ));
+}
+
+#[derive(Component)]
+struct StartPos(f32);
+
+fn explode(
+    mut commands: Commands,
+    keys: Res<ButtonInput<KeyCode>>,
+    mut toggle: Local<Option<(bool, Instant, f32)>>,
+    mut explode_amount: Local<f32>,
+    mut redraw: MessageWriter<RequestRedraw>,
+    mut parts: Query<(Entity, &mut Transform, &Aabb, Option<&StartPos>), With<Mesh3d>>,
+    mut matls: ResMut<Assets<StandardMaterial>>,
+) {
+    let animation = Duration::from_millis(2000);
+    if keys.just_pressed(KeyCode::KeyE) {
+        let new = if let Some((last, ..)) = *toggle {
+            !last
+        } else {
+            true
+        };
+        *toggle = Some((new, Instant::now(), *explode_amount));
+    }
+    if let Some((toggled, start, start_amount)) = *toggle {
+        let goal_amount = toggled as usize as f32;
+        let t = (start.elapsed().as_secs_f32() / animation.as_secs_f32()).clamp(0.0, 1.0);
+        let progress = CubicSegment::new_bezier_easing((0.25, 0.1), (0.25, 1.0)).ease(t);
+        *explode_amount = start_amount + (goal_amount - start_amount) * progress;
+        for (part, mut transform, aabb, start) in &mut parts {
+            let start = if let Some(start) = start {
+                start.0
+            } else {
+                let start = aabb.max().y;
+                commands.entity(part).insert(StartPos(start));
+                start
+            };
+            transform.translation.y = *explode_amount * (start) * 2.0;
+        }
+        if t < 1.0 {
+            redraw.write(RequestRedraw);
+        }
+    }
+    for (_, matl) in matls.iter_mut() {
+        matl.perceptual_roughness = matl.perceptual_roughness.clamp(0.3, 1.0);
+    }
+}
+
+/// Returns the GitHub download URL for the given asset.
+///
+/// The files are expected to be in the [repository].
+///
+/// [repository]: https://github.com/bevyengine/bevy_asset_files
+fn get_web_asset_url(name: &str) -> String {
+    format!(
+        "https://raw.githubusercontent.com/bevyengine/bevy_asset_files/refs/heads/main/{}",
+        name
+    )
+}

--- a/examples/camera/pan_orbit_camera_minimal.rs
+++ b/examples/camera/pan_orbit_camera_minimal.rs
@@ -1,0 +1,41 @@
+//! A minimal example showing the steps needed to get started with the plugin.
+//!
+//! Controls:
+//! - Pan: Left mouse button + drag
+//! - Orbit: Right mouse button + drag
+//! - Zoom: Mouse wheel
+//!
+//! This controller relies on picking to determine what point to orbit around and zoom towards:
+//! your motion will be relative to the point under the mouse cursor.
+
+use bevy::camera_controller::pan_orbit_camera::prelude::*;
+use bevy::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            MeshPickingPlugin, // Step 0: enable some picking backends for hit detection
+            DefaultPanOrbitCameraPlugins, // Step 1: Add camera controller plugin
+        ))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn((
+        Camera3d::default(),
+        PanOrbitCamera::default(), // Step 2: add camera controller component to any cameras
+        EnvironmentMapLight {
+            // EnvironmentMapLight is optional and can be replaced with usual light.
+            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
+            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            intensity: 2500.0,
+            ..default()
+        },
+        Transform::from_xyz(0.0, 0.0, 1.0),
+    ));
+    commands.spawn(WorldAssetRoot(
+        asset_server.load("https://raw.githubusercontent.com/bevyengine/bevy_asset_files/refs/heads/main/PlaneEngine/scene.gltf#Scene0"),
+    ));
+}

--- a/examples/camera/pan_orbit_camera_ortho.rs
+++ b/examples/camera/pan_orbit_camera_ortho.rs
@@ -1,0 +1,100 @@
+//! Demonstrates the use of an orthographic camera with the pan-orbit-zoom controller.
+//!
+//! While this is supported, there are some special considerations when using an orthographic camera.
+//! See comments in the code below!
+
+use bevy::camera_controller::pan_orbit_camera::prelude::*;
+use bevy::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            MeshPickingPlugin,
+            DefaultPanOrbitCameraPlugins,
+        ))
+        .add_systems(Startup, (setup, setup_ui))
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let diffuse_map = asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2");
+    let specular_map = asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2");
+    let translation = Vec3::new(10.0, 10.0, 10.0);
+
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(translation).looking_at(Vec3::ZERO, Vec3::Y),
+        Projection::Orthographic(OrthographicProjection {
+            scale: 0.01,
+            ..OrthographicProjection::default_3d()
+        }),
+        EnvironmentMapLight {
+            intensity: 5000.0,
+            diffuse_map: diffuse_map.clone(),
+            specular_map: specular_map.clone(),
+            rotation: default(),
+            affects_lightmapped_mesh_diffuse: true,
+        },
+        // This component makes the camera controllable with this plugin.
+        //
+        // Important: the `with_initial_anchor_depth` is critical for an orthographic camera. Unlike
+        // perspective, we can't rely on distant things being small to hide precision artifacts.
+        // This means we need to be careful with the near and far plane of the camera, especially
+        // because in orthographic, the depth precision is linear.
+        //
+        // This plugin uses the anchor (the point in space the user is interested in) to set the
+        // orthographic scale, as well as the near and far planes. This can be a bit tricky if you
+        // are unfamiliar with orthographic projections. Consider using an pseudo-ortho projection
+        // if you don't need a true ortho projection.
+        PanOrbitCamera::default().with_initial_anchor_depth(-translation.length() as f64),
+        // This is an extension made specifically for orthographic cameras. Because an ortho camera
+        // projection has no field of view, a skybox can't be sensibly rendered, only a single point
+        // on the skybox would be visible to the camera at any given time. While this is technically
+        // correct to what the camera would see, it is not visually helpful nor appealing. It is
+        // common for CAD software to render a skybox with a field of view that is decoupled from
+        // the camera field of view.
+        bevy::camera_controller::pan_orbit_camera::extensions::independent_skybox::IndependentSkybox::new(
+            diffuse_map,
+            2500.0,
+            default(),
+        ),
+    ));
+
+    spawn_helmets(27, &asset_server, &mut commands);
+}
+
+fn spawn_helmets(n: usize, asset_server: &AssetServer, commands: &mut Commands) {
+    let half_width = ((ops::powf(n as f32, 1.0 / 3.0) - 1.0) / 2.0) as i32;
+    let scene = asset_server.load("https://raw.githubusercontent.com/bevyengine/bevy_asset_files/refs/heads/main/PlaneEngine/scene.gltf#Scene0");
+    let width = -half_width..=half_width;
+    for x in width.clone() {
+        for y in width.clone() {
+            for z in width.clone() {
+                commands.spawn((
+                    WorldAssetRoot(scene.clone()),
+                    Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
+                        .with_scale(Vec3::splat(1.)),
+                ));
+            }
+        }
+    }
+}
+
+fn setup_ui(mut commands: Commands) {
+    let text = "\
+Left Mouse - Pan
+Right Mouse - Orbit
+Scroll - Zoom";
+    commands.spawn((
+        Text::new(text),
+        TextFont {
+            font_size: FontSize::Px(20.0),
+            ..default()
+        },
+        Node {
+            margin: UiRect::all(Val::Px(20.0)),
+            ..Default::default()
+        },
+    ));
+}

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -62,6 +62,10 @@ fn main() {
     .add_systems(OnEnter(Scene::BoxedContent), boxed_content::setup)
     .add_systems(OnEnter(Scene::EditableText), editable_text::setup)
     .add_systems(OnEnter(Scene::NodeMaterial), node_material::setup)
+    .add_systems(
+        OnEnter(Scene::FontRelativeUnits),
+        font_relative_units::setup,
+    )
     .add_systems(Update, switch_scene);
 
     match args.scene {
@@ -109,6 +113,7 @@ enum Scene {
     BoxedContent,
     EditableText,
     NodeMaterial,
+    FontRelativeUnits,
 }
 
 impl Scene {
@@ -137,6 +142,7 @@ impl Scene {
         Scene::BoxedContent,
         Scene::EditableText,
         Scene::NodeMaterial,
+        Scene::FontRelativeUnits,
     ];
 }
 
@@ -3748,5 +3754,152 @@ mod node_material {
                 ),
             ],
         ));
+    }
+}
+
+mod font_relative_units {
+    use bevy::{color::palettes::css::*, prelude::*};
+
+    pub fn setup(mut commands: Commands) {
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::FontRelativeUnits)));
+
+        commands.spawn((
+            Node {
+                width: percent(100),
+                height: percent(100),
+                flex_direction: FlexDirection::Column,
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                row_gap: rem(1),
+                ..default()
+            },
+            BackgroundColor(Color::srgb(0.12, 0.12, 0.16)),
+            DespawnOnExit(super::Scene::FontRelativeUnits),
+            children![text_font_row(12.), text_font_row(24.), text_font_row(36.),],
+        ));
+    }
+
+    fn text_font_row(font_size: f32) -> impl Bundle {
+        (
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                column_gap: rem(1),
+                ..default()
+            },
+            children![
+                (
+                    Node {
+                        width: rem(4),
+                        ..default()
+                    },
+                    Text::new(format!("{font_size}px")),
+                    TextFont::from_font_size(font_size),
+                    TextColor(LAVENDER.into()),
+                ),
+                // `em` padding: scales with this node's own font size.
+                (
+                    Node {
+                        width: rem(20),
+                        justify_content: JustifyContent::Center,
+                        ..default()
+                    },
+                    children![(
+                        Node {
+                            padding: UiRect::all(em(1)),
+                            flex_basis: Val::Auto,
+                            border_radius: em(1).into(),
+                            border: em(0.5).into(),
+                            ..default()
+                        },
+                        EmSize(font_size),
+                        BackgroundColor(DARK_SLATE_BLUE.into()),
+                        BorderColor::all(LAVENDER),
+                        children![(
+                            Text::new("em sizing"),
+                            TextFont::from_font_size(font_size),
+                            BackgroundColor(PEACHPUFF.into()),
+                            TextColor(DARK_SLATE_GRAY.into())
+                        )],
+                    )],
+                ),
+                // Always 10rem across
+                (
+                    Node {
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    EmSize(font_size),
+                    children![(
+                        Node {
+                            width: rem(10),
+                            ..default()
+                        },
+                        Text::new("< rem >"),
+                        TextLayout {
+                            justify: Justify::Center,
+                            ..default()
+                        },
+                        TextFont::from_font_size(font_size),
+                        BackgroundColor(PALE_TURQUOISE.into()),
+                        TextColor(DARK_SLATE_GRAY.into())
+                    )],
+                ),
+                // Grid tracks: left is 5em sized, right is 10rem, padding is 0.5rem
+                (
+                    Node {
+                        width: rem(24),
+                        justify_content: JustifyContent::End,
+                        ..default()
+                    },
+                    children![(
+                        Node {
+                            display: Display::Grid,
+                            grid_template_columns: vec![GridTrack::em(5.), GridTrack::rem(10.)],
+                            padding: px(10).into(),
+                            border_radius: px(10).into(),
+                            border: px(1).into(),
+                            ..default()
+                        },
+                        EmSize(font_size),
+                        BackgroundColor(DARK_SLATE_BLUE.into()),
+                        BorderColor::all(LAVENDER),
+                        children![
+                            (
+                                Node {
+                                    display: Display::Grid,
+                                    grid_column: GridPlacement::span(2),
+                                    ..default()
+                                },
+                                Text::new("px sizing"),
+                                TextFont::from_font_size(px(16)),
+                                TextColor(LAVENDER.into()),
+                            ),
+                            (
+                                Text::new("< em >"),
+                                TextLayout {
+                                    justify: Justify::Center,
+                                    ..default()
+                                },
+                                TextFont::from_font_size(font_size),
+                                BackgroundColor(PEACHPUFF.into()),
+                                TextColor(DARK_SLATE_GRAY.into())
+                            ),
+                            (
+                                Text::new("< rem >"),
+                                TextLayout {
+                                    justify: Justify::Center,
+                                    ..default()
+                                },
+                                TextFont::from_font_size(font_size),
+                                BackgroundColor(PALE_TURQUOISE.into()),
+                                TextColor(DARK_SLATE_GRAY.into())
+                            ),
+                        ]
+                    )]
+                ),
+            ],
+        )
     }
 }

--- a/typos.toml
+++ b/typos.toml
@@ -28,6 +28,7 @@ ser = "ser"       # ron::ser - Serializer
 toi = "toi"       # Time of impact
 vOt = "vOt"
 vOt2 = "vOt2"
+FOV = "FOV"       # Field Of View
 
 [default]
 locale = "en-us"


### PR DESCRIPTION
# Objective

- Previously, it was not possible to cancel tasks on web. Now it is, which means we should be cancelling tasks on web! 

## Solution

- Unconditionally put the load task inside the pending_tasks map. This also required some conditional compilation to reacquire the lock since we have to drop it since the asset load does its first poll immediately.

## Testing

- Updated the cancellation unit test to actually test that the task doesn't make it to returning `Ok` after an await. I ran this test with multi-threaded off before making the fix, and the test blocked. After the fix, it runs fine!

TODO: run tests on wasm/web